### PR TITLE
fix: interest calculations and normalize decimal inputs

### DIFF
--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -202,6 +202,9 @@ export default function DashboardClient() {
       nextForm.termType === "open" ? "monthly" : nextForm.payoutFrequency;
     const interestTreatment =
       payoutFrequency === "monthly" ? "payout" : nextForm.interestTreatment;
+    const existingStatus = editingId
+      ? deposits.find((item) => item.id === editingId)?.status
+      : undefined;
 
     const newDeposit: TimeDeposit = {
       id: editingId ?? `td-${crypto.randomUUID()}`,
@@ -209,7 +212,7 @@ export default function DashboardClient() {
       name: nextForm.name.trim(),
       principal: toNumber(nextForm.principal),
       startDate: nextForm.startDate,
-      termMonths: Math.max(1, toNumber(nextForm.termMonths)),
+      termMonths: Math.max(0.1, toNumber(nextForm.termMonths)),
       interestMode: nextForm.interestMode,
       interestTreatment,
       compounding: nextForm.compounding,
@@ -227,6 +230,7 @@ export default function DashboardClient() {
           : [{ upTo: null, rate: toNumber(nextForm.flatRate) }],
       payoutFrequency,
       isOpenEnded,
+      status: existingStatus ?? "active",
     };
 
     setDeposits((current) => {
@@ -242,11 +246,11 @@ export default function DashboardClient() {
     setDialogOpen(false);
   }
 
-  function seedDemoData() {
+  const seedDemoData = useCallback(() => {
     setDeposits(demoDeposits);
     setSampleDataLoaded(true);
     setSampleDataActive(true);
-  }
+  }, [setDeposits, setSampleDataLoaded, setSampleDataActive]);
 
   function downloadBackup() {
     const payload = {
@@ -355,7 +359,7 @@ export default function DashboardClient() {
     if (deposits.length > 0) return;
     if (sampleDataLoaded || hasCustomData) return;
     seedDemoData();
-  }, [deposits.length, hasCustomData, isReady, sampleDataLoaded]);
+  }, [deposits.length, hasCustomData, isReady, sampleDataLoaded, seedDemoData]);
 
   return (
     <div className="bg-page text-primary min-h-screen">
@@ -365,7 +369,9 @@ export default function DashboardClient() {
           <AlertTitle>Work in progress</AlertTitle>
           <AlertDescription>
             YieldFlow is actively being built. Some features may change as I refine the
-            experience — your data and feedback help shape what comes next.
+            experience — your data and feedback help shape what comes next. Values are
+            estimates and may differ from bank-posted figures since institutions can use
+            different interest conventions (for example, day-count basis like /365).
           </AlertDescription>
         </Alert>
         {showSampleBanner ? (

--- a/src/components/dashboard/__tests__/utils.test.ts
+++ b/src/components/dashboard/__tests__/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  decimalToPercentString,
+  normalizeNumericInput,
+  percentToDecimalString,
+} from "@/components/dashboard/utils";
+
+describe("dashboard utils", () => {
+  it("normalizes floating artifacts from number inputs", () => {
+    expect(normalizeNumericInput("3.2199999999999998", 2)).toBe("3.22");
+    expect(normalizeNumericInput("100.00000000000001", 2)).toBe("100");
+  });
+
+  it("keeps percent conversions stable after normalization", () => {
+    const percent = normalizeNumericInput("5.5000000000000001", 6);
+    const decimal = percentToDecimalString(percent);
+    expect(decimal).toBe("0.055");
+    expect(decimalToPercentString(decimal)).toBe("5.5");
+  });
+});

--- a/src/components/dashboard/utils.ts
+++ b/src/components/dashboard/utils.ts
@@ -1,22 +1,35 @@
 import type { DepositFormErrors, DepositFormState } from "@/components/dashboard/types";
 
+function roundTo(value: number, decimals: number) {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
 export function toNumber(value: string) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function normalizeNumericInput(value: string, decimals = 6) {
+  if (!value) return "";
+  if (value.endsWith(".")) return value;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return value;
+  return String(roundTo(parsed, decimals));
 }
 
 export function decimalToPercentString(value: string) {
   if (!value) return "";
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return "";
-  return String(parsed * 100);
+  return String(roundTo(parsed * 100, 6));
 }
 
 export function percentToDecimalString(value: string) {
   if (!value) return "";
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return "";
-  return String(parsed / 100);
+  return String(roundTo(parsed / 100, 8));
 }
 
 export function validateDeposit(form: DepositFormState) {
@@ -25,7 +38,9 @@ export function validateDeposit(form: DepositFormState) {
   if (!form.name.trim()) errors.name = "Name is required.";
   if (!form.startDate) errors.startDate = "Start date is required.";
   if (toNumber(form.principal) <= 0) errors.principal = "Principal must be > 0.";
-  if (toNumber(form.termMonths) <= 0) errors.termMonths = "Term must be > 0.";
+  if (toNumber(form.termMonths) <= 0) {
+    errors.termMonths = "Term must be > 0 (e.g. 0.5 for 15 days).";
+  }
 
   if (form.interestMode === "simple") {
     if (toNumber(form.flatRate) <= 0) errors.flatRate = "Rate must be > 0.";

--- a/src/lib/__tests__/yield-engine.test.ts
+++ b/src/lib/__tests__/yield-engine.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { calculateNetYield } from "@/lib/yield-engine";
+
+describe("calculateNetYield", () => {
+  it("uses month-based simple-interest math (spreadsheet parity)", () => {
+    const result = calculateNetYield({
+      principal: 250000,
+      startDate: "2025-08-02",
+      termMonths: 6,
+      flatRate: 0.0525,
+      tiers: [{ upTo: null, rate: 0.0525 }],
+      interestMode: "simple",
+      interestTreatment: "payout",
+      compounding: "daily",
+      taxRate: 0.2,
+    });
+
+    expect(result.maturityDate).toBe("2026-02-02");
+    expect(result.grossInterest).toBeCloseTo(6562.5, 6);
+    expect(result.netInterest).toBeCloseTo(5250, 6);
+  });
+
+  it("does not compound when simple mode is set to reinvest", () => {
+    const payout = calculateNetYield({
+      principal: 100000,
+      startDate: "2025-10-24",
+      termMonths: 3,
+      flatRate: 0.055,
+      tiers: [{ upTo: null, rate: 0.055 }],
+      interestMode: "simple",
+      interestTreatment: "payout",
+      compounding: "monthly",
+      taxRate: 0.2,
+    });
+
+    const reinvest = calculateNetYield({
+      principal: 100000,
+      startDate: "2025-10-24",
+      termMonths: 3,
+      flatRate: 0.055,
+      tiers: [{ upTo: null, rate: 0.055 }],
+      interestMode: "simple",
+      interestTreatment: "reinvest",
+      compounding: "monthly",
+      taxRate: 0.2,
+    });
+
+    expect(payout.maturityDate).toBe("2026-01-24");
+    expect(payout.grossInterest).toBeCloseTo(1375, 6);
+    expect(payout.netInterest).toBeCloseTo(1100, 6);
+    expect(reinvest.grossInterest).toBeCloseTo(payout.grossInterest, 8);
+    expect(reinvest.netInterest).toBeCloseTo(payout.netInterest, 8);
+  });
+
+  it("supports fractional term months (0.5 month = 15 days)", () => {
+    const result = calculateNetYield({
+      principal: 100000,
+      startDate: "2026-02-01",
+      termMonths: 0.5,
+      flatRate: 0.06,
+      tiers: [{ upTo: null, rate: 0.06 }],
+      interestMode: "simple",
+      interestTreatment: "payout",
+      compounding: "daily",
+      taxRate: 0.2,
+    });
+
+    expect(result.maturityDate).toBe("2026-02-16");
+    expect(result.dayCount).toBe(15);
+    expect(result.grossInterest).toBeCloseTo(250, 6);
+    expect(result.netInterest).toBeCloseTo(200, 6);
+  });
+});

--- a/src/lib/domain/cashflow.ts
+++ b/src/lib/domain/cashflow.ts
@@ -1,5 +1,5 @@
 import type { MonthlyAllowance, DepositSummary } from "@/lib/types";
-import { addMonths, formatMonthLabel, monthKey } from "@/lib/domain/date";
+import { addMonths, addTermMonths, formatMonthLabel, monthKey } from "@/lib/domain/date";
 
 export function buildMonthlyAllowance(summaries: DepositSummary[]) {
   const map = new Map<string, MonthlyAllowance>();
@@ -7,16 +7,22 @@ export function buildMonthlyAllowance(summaries: DepositSummary[]) {
   for (const summary of summaries) {
     const { deposit, netInterest } = summary;
     const start = new Date(deposit.startDate);
-    const months = Math.max(deposit.termMonths, 1);
-    const monthlyNet =
-      deposit.payoutFrequency === "monthly" ? netInterest / months : netInterest;
+    const termMonths = Math.max(deposit.termMonths, 0.1);
+    const isWholeMonthTerm = Math.abs(termMonths - Math.round(termMonths)) < 1e-9;
+    const payoutDates =
+      deposit.payoutFrequency === "monthly"
+        ? [
+            ...Array.from({ length: Math.floor(termMonths) }, (_, i) =>
+              addMonths(start, i + 1),
+            ),
+            ...(isWholeMonthTerm ? [] : [addTermMonths(start, termMonths)]),
+          ]
+        : [addTermMonths(start, termMonths)];
+    const payoutCount = Math.max(payoutDates.length, 1);
+    const payoutNet =
+      deposit.payoutFrequency === "monthly" ? netInterest / payoutCount : netInterest;
 
-    const payoutCount = deposit.payoutFrequency === "monthly" ? months : 1;
-    for (let i = 0; i < payoutCount; i += 1) {
-      const payoutDate =
-        deposit.payoutFrequency === "monthly"
-          ? addMonths(start, i + 1)
-          : addMonths(start, months);
+    for (const payoutDate of payoutDates) {
       const key = monthKey(payoutDate);
       const label = formatMonthLabel(payoutDate);
       const current = map.get(key) ?? {
@@ -25,13 +31,13 @@ export function buildMonthlyAllowance(summaries: DepositSummary[]) {
         net: 0,
         entries: [],
       };
-      current.net += monthlyNet;
+      current.net += payoutNet;
       current.entries?.push({
         depositId: deposit.id,
         name: deposit.name,
         bankName: summary.bank.name,
         payoutFrequency: deposit.payoutFrequency,
-        amountNet: monthlyNet,
+        amountNet: payoutNet,
         principalReturned: deposit.payoutFrequency === "maturity" ? deposit.principal : 0,
         status: deposit.status ?? "active",
       });

--- a/src/lib/domain/date.ts
+++ b/src/lib/domain/date.ts
@@ -8,6 +8,18 @@ export function addMonths(date: Date, months: number) {
   return next;
 }
 
+// Supports fractional tenure. Example: 0.5 month -> 15 days (30-day month basis).
+export function addTermMonths(date: Date, termMonths: number) {
+  const safeMonths = Number.isFinite(termMonths) ? Math.max(termMonths, 0) : 0;
+  const wholeMonths = Math.trunc(safeMonths);
+  const fractionalMonths = safeMonths - wholeMonths;
+  const next = addMonths(date, wholeMonths);
+  if (fractionalMonths <= 0) return next;
+  const extraDays = Math.round(fractionalMonths * 30);
+  next.setDate(next.getDate() + extraDays);
+  return next;
+}
+
 export function toISODate(date: Date) {
   return date.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
## Summary

This PR fixes interest calculation mismatches against expected spreadsheet results, adds decimal tenure support (including 0.5 month).

## Key changes

- Corrected simple-interest calculation to spreadsheet parity:
  - `gross = principal * annualRate * (termMonths / 12)`
  - `net = gross * (1 - taxRate)`
- Removed compounding behavior from `simple` mode even when `interestTreatment = reinvest`.
- Added fractional tenure support:
  - New date utility for fractional terms (`0.5` month = `15` days).
  - Maturity and day-count now use fractional-aware term logic.
  - Cash flow payout scheduling updated to handle fractional terms.
- Fixed edit regression where status was lost:
  - Editing now preserves existing deposit `status` so overdue matured rows keep `Settle` CTA.
- Improved numeric input stability:
  - Added normalization to prevent floating artifacts like `3.2199999999999998`.
  - Applied to key numeric form fields and percent conversions.
- Clarified tier threshold currency:
  - Added visible `PHP` prefix.
- Updated warning/info copy:
  - Work-in-progress banner includes “values are estimates” disclaimer (bank conventions like `/365` may differ).

### Testing
- Percy: https://percy.io/c9665ed5/web/yield-flow-f83e6ca3/builds/47119034