### PR TITLE
refactor(storage): remove localstorage persistence for cleaner state

### DIFF
--- a/src/components/dashboard/EmptyState.tsx
+++ b/src/components/dashboard/EmptyState.tsx
@@ -5,10 +5,9 @@ import { Button } from "@/components/ui/button";
 type Props = {
   onSeed: () => void;
   ctaLabel: string;
-  showCta: boolean;
 };
 
-export default function EmptyState({ onSeed, ctaLabel, showCta }: Props) {
+export default function EmptyState({ onSeed, ctaLabel }: Props) {
   return (
     <div className="border-subtle bg-surface-soft mt-6 flex flex-col items-start gap-4 rounded-2xl border border-dashed p-6 transition-colors duration-200 ease-out">
       <div>
@@ -17,12 +16,10 @@ export default function EmptyState({ onSeed, ctaLabel, showCta }: Props) {
           Load sample data to explore YieldFlow instantly.
         </p>
       </div>
-      {showCta ? (
-        <Button size="sm" onClick={onSeed}>
-          <Database className="h-4 w-4" />
-          {ctaLabel}
-        </Button>
-      ) : null}
+      <Button size="sm" onClick={onSeed}>
+        <Database className="h-4 w-4" />
+        {ctaLabel}
+      </Button>
     </div>
   );
 }

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -2,37 +2,17 @@
 
 import { useEffect } from "react";
 
-type Theme = "light" | "dark" | "system";
+type Theme = "light" | "dark";
 
-const THEME_STORAGE_KEY = "theme";
-
-function resolveTheme(theme: Theme, media: MediaQueryList) {
-  return theme === "system" ? (media.matches ? "dark" : "light") : theme;
-}
-
-function applyTheme(theme: Theme, media: MediaQueryList) {
-  const resolved = resolveTheme(theme, media);
+function applyTheme(theme: Theme) {
   const root = document.documentElement;
-  root.classList.toggle("dark", resolved === "dark");
-  root.style.setProperty("--theme", resolved);
+  root.classList.toggle("dark", theme === "dark");
+  root.style.setProperty("--theme", theme);
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
-    const stored = window.localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
-    const initial: Theme =
-      stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
-
-    applyTheme(initial, media);
-
-    const handleChange = () => applyTheme(initial, media);
-    if (initial === "system") {
-      media.addEventListener("change", handleChange);
-      return () => media.removeEventListener("change", handleChange);
-    }
-
-    return undefined;
+    applyTheme("light");
   }, []);
 
   return <>{children}</>;

--- a/src/components/theme/ThemeToggle.tsx
+++ b/src/components/theme/ThemeToggle.tsx
@@ -11,12 +11,6 @@ const themes = [
   { value: "dark", label: "Dark", icon: Moon },
 ] as const;
 
-const THEME_STORAGE_KEY = "theme";
-
-function getSystemTheme(media: MediaQueryList): Theme {
-  return media.matches ? "dark" : "light";
-}
-
 function applyTheme(theme: Theme) {
   const root = document.documentElement;
   root.classList.toggle("dark", theme === "dark");
@@ -24,45 +18,21 @@ function applyTheme(theme: Theme) {
 }
 
 export default function ThemeToggle() {
-  const [themeState, setThemeState] = useState<{ theme: Theme; followSystem: boolean }>(
-    () => {
-      if (typeof window === "undefined") {
-        return { theme: "light", followSystem: true };
-      }
-      const media = window.matchMedia("(prefers-color-scheme: dark)");
-      const stored = window.localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
-      if (stored === "light" || stored === "dark") {
-        return { theme: stored, followSystem: false };
-      }
-      return { theme: getSystemTheme(media), followSystem: true };
-    },
-  );
+  const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
-    applyTheme(themeState.theme);
-
-    const handleChange = () => {
-      setThemeState((current) => {
-        if (!current.followSystem) return current;
-        const next = getSystemTheme(media);
-        return current.theme === next ? current : { ...current, theme: next };
-      });
-    };
-    media.addEventListener("change", handleChange);
-    return () => media.removeEventListener("change", handleChange);
-  }, [themeState.theme]);
+    applyTheme(theme);
+  }, [theme]);
 
   return (
     <ToggleGroup
       type="single"
-      value={themeState.theme}
+      value={theme}
       suppressHydrationWarning
       onValueChange={(value) => {
         if (!value) return;
         const next = value as Theme;
-        setThemeState({ theme: next, followSystem: false });
-        window.localStorage.setItem(THEME_STORAGE_KEY, next);
+        setTheme(next);
         applyTheme(next);
       }}
       className="bg-card flex-nowrap rounded-full border border-indigo-200 p-1 px-1 dark:border-indigo-500/30"

--- a/src/lib/state/useLocalStorage.ts
+++ b/src/lib/state/useLocalStorage.ts
@@ -2,7 +2,15 @@
 
 import { useEffect, useState } from "react";
 
-export function useLocalStorage<T>(key: string, initialValue: T) {
+type UseLocalStorageOptions<T> = {
+  persistWhen?: (value: T) => boolean;
+};
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+  options?: UseLocalStorageOptions<T>,
+) {
   const [value, setValue] = useState<T>(initialValue);
   const [isReady, setIsReady] = useState(false);
 
@@ -23,8 +31,10 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
 
   useEffect(() => {
     if (!isReady) return;
+    const shouldPersist = options?.persistWhen ? options.persistWhen(value) : true;
+    if (!shouldPersist) return;
     window.localStorage.setItem(key, JSON.stringify(value));
-  }, [key, value, isReady]);
+  }, [isReady, key, options, value]);
 
   return { value, setValue, isReady } as const;
 }


### PR DESCRIPTION
## Summary
- Update behaviour so app starts in an empty state (no automatic sample preload).
- Data Management status badge behavior:
  - `Not saved yet` on first load
  - `Saved to Browser` only after user-owned persistence
- Added explicit localStorage constraints:
  - Sample seed data is session-only (in-memory) and never persisted
  - No storage reads/writes on initial empty render
  - Persistence starts only after user-owned actions (manual add/edit/delete/settle, JSON import)
  - `Clear All Data` removes `yieldflow-deposits` key entirely (no `[]` write)
- Documented theme constraint:
  - Always initializes in light mode
  - No theme localStorage usage
