### PR TITLE
fix: set the calendar timezone to user's local timezone

### DIFF
--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -37,10 +37,11 @@ function isValidDate(date: Date | undefined) {
 interface DatePickerProps {
   id: string
   selected: Date | undefined
+  timeZone?: string
   onSelect: (date: Date | undefined) => void // Allow undefined if user clears input
 }
 
-export function DatePicker({ id, selected, onSelect }: DatePickerProps) {
+export function DatePicker({ id, selected, timeZone, onSelect }: DatePickerProps) {
   const [open, setOpen] = React.useState(false)
   const [month, setMonth] = React.useState<Date | undefined>(selected)
   const [value, setValue] = React.useState(formatDate(selected))
@@ -94,6 +95,7 @@ export function DatePicker({ id, selected, onSelect }: DatePickerProps) {
               mode="single"
               selected={selected}
               month={month}
+              timeZone={timeZone}
               onMonthChange={setMonth}
               onSelect={(date) => {
                 onSelect(date)

--- a/src/features/dashboard/components/CashFlowTab.tsx
+++ b/src/features/dashboard/components/CashFlowTab.tsx
@@ -305,7 +305,7 @@ export function CashFlowTab({ monthlyAllowance, currentMonthFull }: CashFlowTabP
       <div className="flex flex-wrap items-center justify-between gap-4">
         <p className="flex gap-1 items-center text-xs text-muted-foreground">
           <Info className="shrin-0" size="13" aria-hidden="true" />
-          All amounts are net of 20% withholding tax
+          All amounts are net of withholding tax
         </p>
         <WindowFilter value={window} onChange={setWindow} />
       </div>

--- a/src/features/dashboard/components/wizard/InvestmentForm.tsx
+++ b/src/features/dashboard/components/wizard/InvestmentForm.tsx
@@ -40,6 +40,7 @@ interface InvestmentFormProps {
   setField: <K extends keyof WizardFormState>(key: K, value: WizardFormState[K]) => void;
   touchField: (key: keyof WizardFormState) => void;
   existingBankNames: string[];
+  timeZone?: string
 }
 
 // ─── Product type cards ───────────────────────────────────────────────────────
@@ -198,6 +199,7 @@ export function InvestmentForm({
   setField,
   touchField,
   existingBankNames,
+  timeZone,
 }: InvestmentFormProps) {
   const principalCurrencyProps = useCurrencyInput({
     value: formState.principal,
@@ -318,6 +320,7 @@ export function InvestmentForm({
         <DatePicker
           id="inv-start-date"
           selected={startDateObj}
+          timeZone={timeZone}
           onSelect={handleStartDateSelect}
         />
       </Field>

--- a/src/features/dashboard/components/wizard/InvestmentWizard.tsx
+++ b/src/features/dashboard/components/wizard/InvestmentWizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -63,6 +63,12 @@ export function InvestmentWizard({
   } = useWizardState();
 
   const isEditing = !!initialDeposit;
+
+  const [timeZone, setTimeZone] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    setTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone)
+  }, [])
 
   useEffect(() => {
     if (open) {
@@ -164,6 +170,7 @@ export function InvestmentWizard({
                 setField={setField}
                 touchField={touchField}
                 existingBankNames={existingBankNames}
+                timeZone={timeZone}
               />
             </div>
 

--- a/src/features/dashboard/components/wizard/LiveCalcPreview.tsx
+++ b/src/features/dashboard/components/wizard/LiveCalcPreview.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { calculateNetYield } from "@/lib/domain/yield-engine";
 import type { YieldInput } from "@/lib/domain/yield-engine";
 import { formatPhpCurrency } from "@/lib/domain/format";
+import { Badge } from '@/components/ui/badge';
 
 interface LiveCalcPreviewProps {
   input: YieldInput | null;
@@ -87,6 +88,9 @@ export function LiveCalcPreview({ input, compact = false }: LiveCalcPreviewProps
 
       {result ? (
         <>
+          <Badge variant="warning">
+            ESTIMATE
+          </Badge>
           <div className="space-y-3">
             <div>
               <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
The selected date from the calendar is being offset by a day.
Add `timeZone` using the user's timezone to normalize

Ref: https://ui.shadcn.com/docs/components/radix/calendar#selected-date-with-timezone

### Testing
- Percy: https://percy.io/c9665ed5/web/yield-flow-f83e6ca3/builds/47249321
