### PR TITLE
test: cover live calc preview in screenshot testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 
 # testing
 /coverage
-test-results/.last-run.json
+test-results/
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "test:e2e": "PLAYWRIGHT_WEB_SERVER=1 playwright test --project=e2e",
     "test:a11y": "PLAYWRIGHT_WEB_SERVER=1 playwright test --project=a11y",
+    "test:ui": "playwright test --ui",
     "test:percy": "npm run build && PLAYWRIGHT_WEB_SERVER=1 PLAYWRIGHT_WEB_SERVER_CMD=\"npm run start -- --hostname 127.0.0.1 --port 4173\" percy exec -- playwright test --project=e2e"
   },
   "dependencies": {

--- a/tests/flows/add-investment.spec.ts
+++ b/tests/flows/add-investment.spec.ts
@@ -24,6 +24,8 @@ test("add an investment via wizard — empty state → portfolio visible", async
   await page.getByRole("radio", { name: /Time Deposit/ }).click();
   await page.getByRole("radio", { name: "6 mo" }).click();
 
+  // Wait for the live calc preview to load - this will change over time in Percy screenshot
+  await expect(page.getByText("Net interest", { exact: true })).toBeVisible()
   await percySnapshot(page, "Add Investment Dialog — filled");
 
   // Submit

--- a/tests/flows/edit-investment.spec.ts
+++ b/tests/flows/edit-investment.spec.ts
@@ -44,6 +44,9 @@ test("edit an investment — values persist after save", async ({ page }) => {
   // Dialog should open in edit mode
   await expect(page.getByRole("dialog")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Edit investment" })).toBeVisible();
+
+  // Wait for the live calc preview to load - this will change over time in Percy screenshot
+  await expect(page.getByText("Estimate only")).toBeVisible()
   await percySnapshot(page, "Edit Investment Dialog");
 
   // Change the bank name


### PR DESCRIPTION
## Summary
Missed opportunity in covering the live calc preview. We'll wait for it to load before taking a screenshot.
Since date is relative, it will change over time, but that is easy to make sense of at this point.

### Testing
Percy: https://percy.io/c9665ed5/web/yield-flow-f83e6ca3/builds/47250250