### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pbsabella/yield-flow/security/code-scanning/1](https://github.com/pbsabella/yield-flow/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block that scopes down the `GITHUB_TOKEN` to the minimal required access. Since this workflow only checks out code and runs tests, the minimal safe default is `contents: read` at the workflow (root) level so that it applies to all jobs. If in the future a job needs broader permissions, they can be overridden per job without affecting others.

Concretely, in `.github/workflows/ci.yml`, add a `permissions:` section near the top, alongside `name` and `on`. Set it to `contents: read`, which is sufficient for `actions/checkout` and read‑only operations. No other files need changes, and no functionality of the existing steps (linting, testing, Playwright, Percy) depends on write permissions to the repository, so behavior remains the same except for improved security posture.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
