### PR TITLE
chore: add google site verification

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,6 +41,9 @@ export const metadata: Metadata = {
     title: "YieldFlow Lab",
     description: "Visualize spendable reality with net-of-tax interest tracking.",
   },
+  verification: {
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
### Summary
Adds the Google Site Verification metadata to the root layout to enable ownership verification in Google Search Console.

**Changes**
- Configured the verification object within the Next.js Metadata API.
- Utilized the `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` environment variable for the tag value.

**Verification Steps**
- Confirm the `<meta name="google-site-verification" content="...">` tag appears in the <head> of the production deployment.
- Verify ownership in the Google Search Console dashboard.