### PR TITLE
fix: use termDays in investments table calculation to sync it with the modal

### DIFF
--- a/src/lib/domain/interest.ts
+++ b/src/lib/domain/interest.ts
@@ -36,6 +36,7 @@ export function buildDepositSummary(deposit: TimeDeposit, bank: Bank): DepositSu
     principal: deposit.principal,
     startDate: deposit.startDate,
     termMonths: deposit.termMonths,
+    termDays: deposit.termDays,
     flatRate: deposit.flatRate,
     tiers: deposit.tiers,
     interestMode: deposit.interestMode,


### PR DESCRIPTION
## Summary
The expected net interests in the edit modal and the table are different since they used different calculation method