### PR TITLE
style: optimize demo banner in mobile devices

### DIFF
--- a/src/features/dashboard/components/DemoBanner.tsx
+++ b/src/features/dashboard/components/DemoBanner.tsx
@@ -6,19 +6,17 @@ interface DemoBannerProps {
 
 export function DemoBanner({ onExit }: DemoBannerProps) {
   return (
-    <div className="flex flex-wrap items-center justify-center text-center gap-2 border-b border-banner-border bg-banner-bg px-4 py-2 text-xs text-banner-fg">
-      <div className="flex flex-wrap items-center justify-center text-center gap-2">
-        <FlaskConical className="size-3.5 shrink-0" aria-hidden="true" />
-        <span>
-          <span className="font-semibold">Demo mode</span>
-          {" · "}
-          You&apos;re exploring sample data. Nothing is saved.
-        </span>
-      </div>
+    <div className="text-center gap-2 border-b border-banner-border bg-banner-bg px-4 py-2 text-xs text-banner-fg">
+      <FlaskConical className="size-3.5 shrink-0 inline-block mr-1 align-text-bottom" aria-hidden="true" />
+      <span>
+        <span className="font-semibold">Demo mode</span>
+        {" · "}
+        You&apos;re exploring sample data. Nothing is saved.
+      </span>
       <button
         onClick={onExit}
         aria-label="Exit demo mode"
-        className="flex items-center gap-1 text-banner-fg transition-colors hover:text-banner-fg underline"
+        className="inline-block ml-2 text-banner-fg transition-colors hover:text-banner-fg underline"
       >
         Exit Demo
       </button>


### PR DESCRIPTION
## Overview
Reduce the space taken up by the flex behaviour

### Testing
Before:
<img width="399" height="220" alt="Screenshot 2026-03-01 at 2 10 54 PM" src="https://github.com/user-attachments/assets/d79ed284-5cfc-4337-8572-5342514455e1" />

After
<img width="399" height="179" alt="Screenshot 2026-03-01 at 2 11 18 PM" src="https://github.com/user-attachments/assets/b9f99534-751f-489a-97cf-df38efb7e72b" />
