### PR TITLE
feat: early account closure, navigation badges, and architectural cleanup

### DIFF
--- a/.claude/yieldflow-skill/references/ENGINEERING.md
+++ b/.claude/yieldflow-skill/references/ENGINEERING.md
@@ -117,6 +117,30 @@ Priority chain: Domain Rules → Engineering Tokens → External Skill suggestio
 
 ---
 
+## Testing
+
+Every new feature or page requires coverage across all three layers:
+
+| Layer | Tool | Location | When to write |
+| ----- | ---- | -------- | ------------- |
+| **Unit / integration** | Vitest + React Testing Library | `src/**/__tests__/` | Domain logic, hooks, complex components with branching render paths |
+| **E2E flow** | Playwright | `tests/flows/` | Full user flows (add, edit, delete, close, import, export) |
+| **A11y** | axe-core + Playwright | `tests/a11y/basic.a11y.spec.ts` | Every new page and every new dialog/menu that opens |
+
+**A11y test rules:**
+
+- Scope `AxeBuilder` to the component under test (`include('[role="dialog"]')`, `include('[role="menu"]')`) when a popup hides background elements via `aria-hidden`. Analyzing the full page while a modal/dropdown is open produces false positives for `aria-hidden-focus` on background focusable elements.
+- Decorative containers already marked `aria-hidden="true"` are not excluded automatically by axe for color-contrast; scope the analysis or use `.exclude()` to avoid flagging them.
+- Filter violations to `critical` and `serious` impact only (`v.impact === "critical" || v.impact === "serious"`).
+
+**E2E test rules:**
+
+- Cross-page tests (navigate from page A → action → navigate to page B → assert) are fragile due to the React state → `useLocalStorage` effect → page reload hydration chain. Prefer asserting the result on the same page, or split into independent tests.
+- Avoid `{ exact: true }` on `getByText` when the text is unique in its visual context. Use a scoped locator instead (e.g. `page.getByRole("row").filter({ hasText: "..." }).getByText("Closed")`).
+- Freeze time with `page.clock.setFixedTime` before `page.addInitScript` and `page.goto` so it applies to the initial load. The clock persists within the same Playwright browser context.
+
+---
+
 ## What NOT to Do
 
 - Show gross values in any primary view

--- a/.claude/yieldflow-skill/references/PRODUCT.md
+++ b/.claude/yieldflow-skill/references/PRODUCT.md
@@ -60,28 +60,28 @@ Controls: bank filter select, Show settled toggle (off by default), List / Ladde
 
 **Days to Maturity pill:** neutral → "7 days" → "Due today" / amber → "Overdue X days" / open-ended → "—"
 **Matured/overdue row:** amber highlight; Settle CTA visible.
-**Show closed / settled toggle:** closed and settled deposits hidden by default; shown when toggled on.
-**Actions:** Edit (opens wizard), Settle (confirmation dialog), Delete (confirmation dialog), Close Early / Close Account (··· menu, active rows only), Undo Settle (··· menu, settled rows only), Reopen (··· menu, closed rows only), Roll Over (inside Settle dialog, matured rows only).
+**Show inactive toggle:** closed and settled deposits hidden by default; shown when toggled on.
+**Actions:** Edit (opens wizard), Settle (confirmation dialog), Delete (confirmation dialog), Close early / Withdraw & close (··· menu, active rows only), Undo settle (··· menu, settled rows only), Reopen (··· menu, closed rows only), Roll over (inside Settle dialog, matured rows only).
 
-#### Close Account / Close Early
+#### Withdraw & close / Close early
 
-Available in the `···` menu for any **active** deposit. TDs show "Close Early" with a warning banner (maturity date + days remaining). Open-ended savings show "Close Account" with no warning.
+Available in the `···` menu for any **active** deposit. TDs show "Close early" with a warning banner (maturity date + days remaining). Open-ended savings show "Withdraw & close" with no warning.
 
 Dialog shows: Principal | Accrued net interest | Net proceeds. After confirm: toast with inline Undo.
 
 #### Reopen
 
-Reverts a `closed` deposit back to `active`. In the `···` menu on closed rows (requires "Show closed / settled" toggled on). No confirmation dialog.
+Reverts a `closed` deposit back to `active`. In the `···` menu on closed rows (requires "Show inactive" toggled on). No confirmation dialog.
 
-#### Undo Settle
+#### Undo settle
 
-Reverts a `settled` deposit back to `matured`. Available in the `···` menu on settled rows when "Show closed / settled" is toggled on. Pure status revert — no math. Mirrors the Settle handler in reverse.
+Reverts a `settled` deposit back to `matured`. Available in the `···` menu on settled rows when "Show inactive" is toggled on. Pure status revert — no math. Mirrors the Settle handler in reverse.
 
-#### Roll Over
+#### Roll over
 
-Available as a secondary action inside the Settle confirmation dialog (matured deposits only). The dialog shows: `[ Cancel ] [ Roll Over ] [ Settle ₱X ]` — amount only on Settle since Roll Over opens an editable wizard.
+Available as a secondary action inside the Settle confirmation dialog (matured deposits only). The dialog shows: `[ Cancel ] [ Roll over ] [ Settle ₱X ]` — amount only on Settle since Roll over opens an editable wizard.
 
-On Roll Over click: dialog closes, wizard opens pre-filled. Fields copied from original deposit: bank, product type, interest rate, tax rate, term, day-count, compounding, interest mode. Fields overridden:
+On Roll over click: dialog closes, wizard opens pre-filled. Fields copied from original deposit: bank, product type, interest rate, tax rate, term, day-count, compounding, interest mode. Fields overridden:
 
 | Field | Value |
 | --- | --- |

--- a/.claude/yieldflow-skill/references/PRODUCT.md
+++ b/.claude/yieldflow-skill/references/PRODUCT.md
@@ -17,14 +17,14 @@
 
 ## Domain Logic
 
-| Concept       | Rule                                                                |
-| ------------- | ------------------------------------------------------------------- |
-| Display       | Net of tax only. Principal return is not income.                    |
-| Status        | `active` → `matured` (auto) → `settled` (explicit user action only) |
-| Principal     | `active` + `matured` count. `settled` excluded.                     |
-| Interest Mode | `simple` (flat rate) or `tiered` (brackets by principal balance)    |
-| Term input    | Months (default) **or** `termDays` (takes precedence when set)      |
-| Day-count     | 360 or 365 toggle; default 365                                      |
+| Concept       | Rule                                                                                                  |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| Display       | Net of tax only. Principal return is not income.                                                      |
+| Status        | `active` → `matured` (auto) → `settled` (explicit). Or `active` → `closed` (explicit early closure). |
+| Principal     | `active` + `matured` count. `settled` and `closed` excluded.                                          |
+| Interest Mode | `simple` (flat rate) or `tiered` (brackets by principal balance)                                      |
+| Term input    | Months (default) **or** `termDays` (takes precedence when set)                                        |
+| Day-count     | 360 or 365 toggle; default 365                                                                        |
 
 ---
 
@@ -60,12 +60,22 @@ Controls: bank filter select, Show settled toggle (off by default), List / Ladde
 
 **Days to Maturity pill:** neutral → "7 days" → "Due today" / amber → "Overdue X days" / open-ended → "—"
 **Matured/overdue row:** amber highlight; Settle CTA visible.
-**Show settled toggle:** settled deposits hidden by default; shown dimmed when toggled on.
-**Actions:** Edit (opens wizard), Settle (confirmation dialog), Delete (confirmation dialog), Undo Settle (··· menu, settled rows only), Roll Over (inside Settle dialog, matured rows only).
+**Show closed / settled toggle:** closed and settled deposits hidden by default; shown when toggled on.
+**Actions:** Edit (opens wizard), Settle (confirmation dialog), Delete (confirmation dialog), Close Early / Close Account (··· menu, active rows only), Undo Settle (··· menu, settled rows only), Reopen (··· menu, closed rows only), Roll Over (inside Settle dialog, matured rows only).
+
+#### Close Account / Close Early
+
+Available in the `···` menu for any **active** deposit. TDs show "Close Early" with a warning banner (maturity date + days remaining). Open-ended savings show "Close Account" with no warning.
+
+Dialog shows: Principal | Accrued net interest | Net proceeds. After confirm: toast with inline Undo.
+
+#### Reopen
+
+Reverts a `closed` deposit back to `active`. In the `···` menu on closed rows (requires "Show closed / settled" toggled on). No confirmation dialog.
 
 #### Undo Settle
 
-Reverts a `settled` deposit back to `matured`. Available in the `···` menu on settled rows when Show Settled is toggled on. Pure status revert — no math. Mirrors the Settle handler in reverse.
+Reverts a `settled` deposit back to `matured`. Available in the `···` menu on settled rows when "Show closed / settled" is toggled on. Pure status revert — no math. Mirrors the Settle handler in reverse.
 
 #### Roll Over
 
@@ -101,6 +111,8 @@ Rolling window with filter: **3M / 6M / 12M / All**. Default 12M. Months with no
 
 **Open-ended deposits:** Projected as 12 monthly payouts anchored to the deposit's `startDate`.
 The first projected month is the earliest payout month ≥ the current calendar month.
+
+**Closed deposits:** Excluded from future projections. A single historical entry appears in the `closeDate` month showing accrued net interest + principal returned, with a "Closed" pill.
 
 ---
 

--- a/docs/ux-decisions.md
+++ b/docs/ux-decisions.md
@@ -303,8 +303,9 @@ Within each expanded month, entries are grouped under "At maturity payouts" and 
 
 Within the **current month** entry list only:
 
-- `matured` entries → "Due now" alert badge (action needed)
-- `settled` entries → "Settled" success badge (muted signal)
+- `matured` entries → "Matured" warning badge (action needed)
+- `settled` entries → "Settled" success badge
+- `closed` entries → "Closed" alert badge
 - `active` entries → no badge (self-evidently pending)
 
 **Decision:** "Pending" label was removed from active entries. An active deposit in the current month's list is self-evidently pending — the label stated the obvious.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,6 +191,8 @@
   --color-banner-fg: oklch(0.38 0.17 277);
   --color-banner-border: oklch(0.88 0.06 277);
 
+  --dropdown-content-min-w: 14ch;
+
   /* Frozen (sticky) table column — faint indigo wash, distinct from white rows */
   --color-table-frozen-bg: oklch(0.975 0.012 277);
 

--- a/src/components/layout/BottomTabBar.tsx
+++ b/src/components/layout/BottomTabBar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LayoutDashboard, LayoutList, Plus, Settings, TrendingUp } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { usePortfolioContext } from "@/features/portfolio/context/PortfolioContext";
 
@@ -21,11 +22,13 @@ function NavTab({
   label,
   icon: Icon,
   active,
+  badge,
 }: {
   href: string;
   label: string;
   icon: React.ElementType;
   active: boolean;
+  badge?: React.ReactNode;
 }) {
   return (
     <Link
@@ -38,7 +41,10 @@ function NavTab({
       )}
       aria-current={active ? "page" : undefined}
     >
-      <Icon className={cn("size-5", active && "text-sidebar-primary")} aria-hidden="true" />
+      <span className="relative">
+        <Icon className={cn("size-5", active && "text-sidebar-primary")} aria-hidden="true" />
+        {badge}
+      </span>
       {label}
     </Link>
   );
@@ -46,7 +52,9 @@ function NavTab({
 
 export function BottomTabBar() {
   const pathname = usePathname();
-  const { openWizard, hasSidebar } = usePortfolioContext();
+  const { openWizard, hasSidebar, portfolio } = usePortfolioContext();
+
+  const maturedCount = portfolio.summaries.filter((s) => s.effectiveStatus === "matured").length;
 
   if (!hasSidebar) return null;
 
@@ -57,7 +65,24 @@ export function BottomTabBar() {
     >
       {/* Left tabs */}
       {LEFT_TABS.map(({ href, label, icon }) => (
-        <NavTab key={href} href={href} label={label} icon={icon} active={pathname === href} />
+        <NavTab
+          key={href}
+          href={href}
+          label={label}
+          icon={icon}
+          active={pathname === href}
+          badge={
+            href === "/investments" && maturedCount > 0 ? (
+              <Badge
+                variant="default"
+                size="xs"
+                className="absolute -top-1 -right-2.5 min-w-3.5 tabular-nums"
+              >
+                {maturedCount}
+              </Badge>
+            ) : undefined
+          }
+        />
       ))}
 
       {/* Center Add button */}

--- a/src/components/layout/SidebarNav.tsx
+++ b/src/components/layout/SidebarNav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { LayoutDashboard, LayoutList, Settings, TrendingUp } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { usePortfolioContext } from "@/features/portfolio/context/PortfolioContext";
 
 const NAV_ITEMS = [
   { href: "/", label: "Dashboard", icon: LayoutDashboard },
@@ -18,11 +19,13 @@ function NavItem({
   label,
   icon: Icon,
   active,
+  badge,
 }: {
   href: string;
   label: string;
   icon: React.ElementType;
   active: boolean;
+  badge?: React.ReactNode;
 }) {
   return (
     <Link
@@ -36,13 +39,19 @@ function NavItem({
       aria-current={active ? "page" : undefined}
     >
       <Icon className="size-4 shrink-0" aria-hidden="true" />
-      {label}
+      <span className="flex-1">{label}</span>
+      {badge}
     </Link>
   );
 }
 
 export function SidebarNav() {
   const pathname = usePathname();
+  const { portfolio, hasSidebar } = usePortfolioContext();
+
+  const maturedCount = hasSidebar
+    ? portfolio.summaries.filter((s) => s.effectiveStatus === "matured").length
+    : 0;
 
   return (
     <div className="flex h-full flex-col bg-sidebar border-r border-sidebar-border">
@@ -63,6 +72,13 @@ export function SidebarNav() {
             label={label}
             icon={icon}
             active={pathname === href}
+            badge={
+              href === "/investments" && maturedCount > 0 ? (
+                <Badge variant="default" size="sm" className="min-w-4 tabular-nums">
+                  {maturedCount}
+                </Badge>
+              ) : undefined
+            }
           />
         ))}
       </nav>

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,13 +1,13 @@
 import { Badge } from "@/components/ui/badge";
-
-type InvestmentStatus = "active" | "matured" | "settled";
+import type { TimeDeposit } from "@/types";
 
 interface StatusBadgeProps {
-  status: InvestmentStatus;
+  status: TimeDeposit["status"];
 }
 
 export function StatusBadge({ status }: StatusBadgeProps) {
   if (status === "settled") return <Badge variant="success">Settled</Badge>;
   if (status === "matured") return <Badge variant="warning">Matured</Badge>;
+  if (status === "closed") return <Badge variant="alert">Closed</Badge>;
   return <Badge variant="secondary">Active</Badge>;
 }

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,8 +1,8 @@
 import { Badge } from "@/components/ui/badge";
-import type { TimeDeposit } from "@/types";
+import type { EffectiveStatus } from "@/features/portfolio/hooks/usePortfolioData";
 
 interface StatusBadgeProps {
-  status: TimeDeposit["status"];
+  status: EffectiveStatus;
 }
 
 export function StatusBadge({ status }: StatusBadgeProps) {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -20,9 +20,15 @@ const badgeVariants = cva(
         // @shadcn-override: spread status variants from variants.ts
         ...badgeStatusVariants,
       },
+      size: {
+        default: "",
+        sm: "h-4 px-1 py-0 text-[10px] leading-none",
+        xs: "h-3.5 px-0.5 py-0 text-[9px] leading-none",
+      },
     },
     defaultVariants: {
       variant: "default",
+      size: "default",
     },
   }
 )
@@ -31,6 +37,7 @@ const badgeVariants = cva(
 function Badge({
   className,
   variant = "default",
+  size = "default",
   asChild = false,
   ...props
 }: React.ComponentProps<"span"> &
@@ -41,7 +48,7 @@ function Badge({
     <Comp
       data-slot="badge"
       data-variant={variant}
-      className={cn(badgeVariants({ variant }), className)}
+      className={cn(badgeVariants({ variant, size }), className)}
       {...props}
     />
   )

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -43,7 +43,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         align={align}
-        className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden", className )}
+        className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-(--dropdown-content-min-w) rounded-lg p-1 shadow-md ring-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden", className )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>

--- a/src/features/cashflow/components/CashFlowView.tsx
+++ b/src/features/cashflow/components/CashFlowView.tsx
@@ -223,17 +223,17 @@ function EntryGroup({
               </span>
               <span className="flex items-center gap-1.5 shrink-0">
                 {isCurrent && entry.status === "matured" && (
-                  <Badge variant="warning" className="text-xs h-4 font-normal">
+                  <Badge variant="warning" size="sm" className="font-normal">
                     Matured
                   </Badge>
                 )}
                 {isCurrent && isSettled && (
-                  <Badge variant="success" className="text-xs h-4 font-normal">
+                  <Badge variant="success" size="sm" className="font-normal">
                     Settled
                   </Badge>
                 )}
                 {entry.status === "closed" && (
-                  <Badge variant="alert" className="text-xs h-4 font-normal">
+                  <Badge variant="alert" size="sm" className="font-normal">
                     Closed
                   </Badge>
                 )}

--- a/src/features/cashflow/components/CashFlowView.tsx
+++ b/src/features/cashflow/components/CashFlowView.tsx
@@ -223,13 +223,18 @@ function EntryGroup({
               </span>
               <span className="flex items-center gap-1.5 shrink-0">
                 {isCurrent && entry.status === "matured" && (
-                  <Badge variant="alert" className="text-xs h-4 font-normal">
+                  <Badge variant="warning" className="text-xs h-4 font-normal">
                     Due now
                   </Badge>
                 )}
                 {isCurrent && isSettled && (
                   <Badge variant="success" className="text-xs h-4 font-normal">
                     Settled
+                  </Badge>
+                )}
+                {entry.status === "closed" && (
+                  <Badge variant="alert" className="text-xs h-4 font-normal">
+                    Closed
                   </Badge>
                 )}
                 <span

--- a/src/features/cashflow/components/CashFlowView.tsx
+++ b/src/features/cashflow/components/CashFlowView.tsx
@@ -224,7 +224,7 @@ function EntryGroup({
               <span className="flex items-center gap-1.5 shrink-0">
                 {isCurrent && entry.status === "matured" && (
                   <Badge variant="warning" className="text-xs h-4 font-normal">
-                    Due now
+                    Matured
                   </Badge>
                 )}
                 {isCurrent && isSettled && (

--- a/src/features/dashboard/components/__tests__/KpiCards.test.tsx
+++ b/src/features/dashboard/components/__tests__/KpiCards.test.tsx
@@ -4,7 +4,7 @@ import { KpiCards } from "@/features/dashboard/components/KpiCards";
 import { PortfolioProvider } from "@/features/portfolio/context/PortfolioContext";
 import type { CurrentMonthBreakdown, NextMaturity } from "@/features/portfolio/hooks/usePortfolioData";
 
-const emptyBreakdown: CurrentMonthBreakdown = { net: 0, pendingNet: 0, settledNet: 0 };
+const emptyBreakdown: CurrentMonthBreakdown = { net: 0, pendingNet: 0, settledNet: 0, closedNet: 0 };
 
 function renderKpiCards(props: Parameters<typeof KpiCards>[0]) {
   return render(
@@ -36,7 +36,7 @@ describe("KpiCards — Total Principal", () => {
 
 describe("KpiCards — Income This Month", () => {
   it("renders net income for the current month", () => {
-    const breakdown: CurrentMonthBreakdown = { net: 12500, pendingNet: 0, settledNet: 0 };
+    const breakdown: CurrentMonthBreakdown = { net: 12500, pendingNet: 0, settledNet: 0, closedNet: 0 };
     renderKpiCards({
       totalPrincipal: 0,
       currentMonthBreakdown: breakdown,
@@ -46,7 +46,7 @@ describe("KpiCards — Income This Month", () => {
   });
 
   it("shows pending and settled pills when both are non-zero", () => {
-    const breakdown: CurrentMonthBreakdown = { net: 3000, pendingNet: 2000, settledNet: 1000 };
+    const breakdown: CurrentMonthBreakdown = { net: 3000, pendingNet: 2000, settledNet: 1000, closedNet: 0 };
     renderKpiCards({
       totalPrincipal: 0,
       currentMonthBreakdown: breakdown,
@@ -60,7 +60,7 @@ describe("KpiCards — Income This Month", () => {
   });
 
   it("shows pending pill but hides settled pill when settledNet is zero", () => {
-    const breakdown: CurrentMonthBreakdown = { net: 2000, pendingNet: 2000, settledNet: 0 };
+    const breakdown: CurrentMonthBreakdown = { net: 2000, pendingNet: 2000, settledNet: 0, closedNet: 0 };
     renderKpiCards({
       totalPrincipal: 0,
       currentMonthBreakdown: breakdown,

--- a/src/features/investments/components/CloseConfirmDialog.tsx
+++ b/src/features/investments/components/CloseConfirmDialog.tsx
@@ -16,17 +16,15 @@ import { formatDate, differenceInCalendarDays, parseLocalDate } from "@/lib/doma
 import type { EnrichedSummary } from "@/features/portfolio/hooks/usePortfolioData";
 
 type Props = {
-  summary: EnrichedSummary | null;
+  summary: EnrichedSummary;
   closeDate: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (id: string) => void;
+  onConfirm: (id: string, closeDate: string) => void;
 };
 
 export function CloseConfirmDialog({ summary, closeDate, open, onOpenChange, onConfirm }: Props) {
   const { fmtCurrency } = useFormatterContext();
-  if (!summary) return null;
-
   const { deposit, bank, maturityDate } = summary;
 
   const accrued = calculateAccruedToDate(deposit, bank, closeDate);
@@ -47,7 +45,7 @@ export function CloseConfirmDialog({ summary, closeDate, open, onOpenChange, onC
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="space-y-2 text-sm">
+            <div className="space-y-2 text-sm w-full">
               {isEarlyClose && daysRemaining !== null && daysRemaining > 0 && (
                 <p className="text-status-warning-fg font-medium">
                   Closing before maturity — {formatDate(parseLocalDate(maturityDate!))}
@@ -78,10 +76,10 @@ export function CloseConfirmDialog({ summary, closeDate, open, onOpenChange, onC
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
-            onClick={() => onConfirm(deposit.id)}
+            onClick={() => onConfirm(deposit.id, closeDate)}
             variant="destructive"
           >
-            Close Account
+            Close account
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/features/investments/components/CloseConfirmDialog.tsx
+++ b/src/features/investments/components/CloseConfirmDialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useFormatterContext } from "@/features/portfolio/context/PortfolioContext";
+import { calculateAccruedToDate } from "@/lib/domain/accrued-interest";
+import { formatDate, differenceInCalendarDays, parseLocalDate } from "@/lib/domain/date";
+import type { EnrichedSummary } from "@/features/portfolio/hooks/usePortfolioData";
+
+type Props = {
+  summary: EnrichedSummary | null;
+  closeDate: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (id: string) => void;
+};
+
+export function CloseConfirmDialog({ summary, closeDate, open, onOpenChange, onConfirm }: Props) {
+  const { fmtCurrency } = useFormatterContext();
+  if (!summary) return null;
+
+  const { deposit, bank, maturityDate } = summary;
+
+  const accrued = calculateAccruedToDate(deposit, bank, closeDate);
+  const netProceeds = deposit.principal + accrued.netInterest;
+
+  const isEarlyClose = !deposit.isOpenEnded && maturityDate !== null;
+  const daysRemaining = isEarlyClose
+    ? differenceInCalendarDays(parseLocalDate(maturityDate!), parseLocalDate(closeDate))
+    : null;
+
+  const title = deposit.isOpenEnded
+    ? `Close ${deposit.name}?`
+    : `Close ${deposit.name} early?`;
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2 text-sm">
+              {isEarlyClose && daysRemaining !== null && daysRemaining > 0 && (
+                <p className="text-status-warning-fg font-medium">
+                  Closing before maturity — {formatDate(parseLocalDate(maturityDate!))}
+                  {" "}({daysRemaining}d remaining)
+                </p>
+              )}
+              <div className="space-y-1">
+                <div className="flex justify-between">
+                  <span>Principal</span>
+                  <span className="font-medium text-foreground">
+                    {fmtCurrency(deposit.principal)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Accrued net interest</span>
+                  <span className="font-medium text-foreground">
+                    {fmtCurrency(accrued.netInterest)}
+                  </span>
+                </div>
+                <div className="flex justify-between border-t pt-1 font-semibold text-foreground gap-8">
+                  <span>Net proceeds</span>
+                  <span>{fmtCurrency(netProceeds)}</span>
+                </div>
+              </div>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => onConfirm(deposit.id)}
+            variant="destructive"
+          >
+            Close Account
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/features/investments/components/DepositActions.tsx
+++ b/src/features/investments/components/DepositActions.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { MoreHorizontal, Pencil, Trash, Undo2, X, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { EnrichedSummary } from "@/features/portfolio/hooks/usePortfolioData";
+import type { TimeDeposit } from "@/types";
+
+type Props = {
+  summary: EnrichedSummary;
+  onSettle: (summary: EnrichedSummary) => void;
+  onUnsettle: (id: string) => void;
+  onClose: (summary: EnrichedSummary) => void;
+  onReopen: (id: string) => void;
+  onEdit: (deposit: TimeDeposit) => void;
+  onDelete: (summary: EnrichedSummary) => void;
+};
+
+export function DepositActions({
+  summary,
+  onSettle,
+  onUnsettle,
+  onClose,
+  onReopen,
+  onEdit,
+  onDelete,
+}: Props) {
+  const { deposit, effectiveStatus } = summary;
+
+  return (
+    <div className="flex items-center justify-end">
+      {effectiveStatus === "matured" && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="rounded-r-none"
+          onClick={() => onSettle(summary)}
+          aria-label={`Settle ${deposit.name}`}
+        >
+          Settle
+        </Button>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="sm"
+            variant="outline"
+            className={
+              effectiveStatus === "matured"
+                ? "rounded-l-none border-l-0 px-2"
+                : "px-2"
+            }
+            aria-label={`More options for ${deposit.name}`}
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {effectiveStatus === "settled" && (
+            <DropdownMenuItem onClick={() => onUnsettle(deposit.id)}>
+              <Undo2 />
+              Undo settle
+            </DropdownMenuItem>
+          )}
+          {effectiveStatus === "closed" && (
+            <DropdownMenuItem onClick={() => onReopen(deposit.id)}>
+              <RefreshCw />
+              Reopen
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem onClick={() => onEdit(deposit)}>
+            <Pencil />
+            Edit
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+
+          {effectiveStatus === "active" && (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={() => onClose(summary)}
+            >
+              <X />
+              {deposit.isOpenEnded ? "Withdraw & close" : "Close early"}
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => onDelete(summary)}
+          >
+            <Trash />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/features/investments/components/DepositCard.tsx
+++ b/src/features/investments/components/DepositCard.tsx
@@ -1,16 +1,9 @@
 "use client";
 
 import { memo } from "react";
-import { MoreHorizontal, Pencil, Trash, Undo2, X, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { CollapsibleCard } from "@/components/ui/CollapsibleCard";
 import { StatusBadge } from "@/components/ui/StatusBadge";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { DepositActions } from "./DepositActions";
 import { useFormatterContext } from "@/features/portfolio/context/PortfolioContext";
 import { formatDate, differenceInCalendarDays, parseLocalDate } from "@/lib/domain/date";
 import { cn } from "@/lib/utils";
@@ -20,7 +13,7 @@ import type { TimeDeposit } from "@/types";
 type Props = {
   summary: EnrichedSummary;
   onSettleClick: (summary: EnrichedSummary) => void;
-  onDeleteClick: (id: string) => void;
+  onDeleteClick: (summary: EnrichedSummary) => void;
   onEditClick: (deposit: TimeDeposit) => void;
   onUnsettleClick: (id: string) => void;
   onCloseClick: (summary: EnrichedSummary) => void;
@@ -37,10 +30,10 @@ function MaturityLabel({
   isOpenEnded?: boolean;
   effectiveStatus: string;
 }) {
-  if (isOpenEnded)
-    return <span className="text-xs text-muted-foreground">Open-ended</span>;
   if (effectiveStatus === "settled" || effectiveStatus === "closed")
     return <span className="text-xs text-muted-foreground">—</span>;
+  if (isOpenEnded)
+    return <span className="text-xs text-muted-foreground">Open-ended</span>;
   if (!maturityDate)
     return <span className="text-xs text-muted-foreground">—</span>;
 
@@ -77,8 +70,6 @@ export const DepositCard = memo(function DepositCard({ summary, onSettleClick, o
   const { fmtCurrency } = useFormatterContext();
   const { deposit, bank, maturityDate, netInterest, effectiveStatus } = summary;
 
-  const statusBadge = <StatusBadge status={effectiveStatus} />;
-
   return (
     <li>
       <article aria-labelledby={`deposit-${deposit.id}-name`}>
@@ -86,7 +77,7 @@ export const DepositCard = memo(function DepositCard({ summary, onSettleClick, o
           cardClassName={cn("transition duration-1000", isNew && "ring-2 ring-primary/40 bg-primary/5")}
           trigger={
             <div className="flex items-center gap-stack-xs">
-              {statusBadge}
+              <StatusBadge status={effectiveStatus} />
               <h2
                 id={`deposit-${deposit.id}-name`}
                 className="text-sm font-medium"
@@ -103,69 +94,15 @@ export const DepositCard = memo(function DepositCard({ summary, onSettleClick, o
                 isOpenEnded={deposit.isOpenEnded}
                 effectiveStatus={effectiveStatus}
               />
-              <div className="flex items-center justify-end">
-                {effectiveStatus === "matured" && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="rounded-r-none"
-                    onClick={() => onSettleClick(summary)}
-                    aria-label={`Settle ${deposit.name}`}
-                  >
-                    Settle
-                  </Button>
-                )}
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className={
-                        effectiveStatus === "matured"
-                          ? "rounded-l-none border-l-0 px-2"
-                          : "px-2"
-                      }
-                      aria-label={`More options for ${deposit.name}`}
-                    >
-                      <MoreHorizontal className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    {effectiveStatus === "settled" && (
-                      <DropdownMenuItem onClick={() => onUnsettleClick(deposit.id)}>
-                        <Undo2 />
-                        Undo Settle
-                      </DropdownMenuItem>
-                    )}
-                    {effectiveStatus === "closed" && (
-                      <DropdownMenuItem onClick={() => onReopenClick(deposit.id)}>
-                        <RefreshCw />
-                        Reopen
-                      </DropdownMenuItem>
-                    )}
-                    {effectiveStatus === "active" && (
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onClick={() => onCloseClick(summary)}
-                      >
-                        <X />
-                        {deposit.isOpenEnded ? "Close Account" : "Close Early"}
-                      </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem onClick={() => onEditClick(deposit)}>
-                      <Pencil />
-                      Edit
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      variant="destructive"
-                      onClick={() => onDeleteClick(deposit.id)}
-                    >
-                      <Trash />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+              <DepositActions
+                summary={summary}
+                onSettle={onSettleClick}
+                onUnsettle={onUnsettleClick}
+                onClose={onCloseClick}
+                onReopen={onReopenClick}
+                onEdit={onEditClick}
+                onDelete={onDeleteClick}
+              />
             </>
           }
           footerClassName="justify-between"

--- a/src/features/investments/components/DepositCard.tsx
+++ b/src/features/investments/components/DepositCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo } from "react";
-import { MoreHorizontal, Pencil, Trash, Undo2 } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash, Undo2, X, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CollapsibleCard } from "@/components/ui/CollapsibleCard";
 import { StatusBadge } from "@/components/ui/StatusBadge";
@@ -23,6 +23,8 @@ type Props = {
   onDeleteClick: (id: string) => void;
   onEditClick: (deposit: TimeDeposit) => void;
   onUnsettleClick: (id: string) => void;
+  onCloseClick: (summary: EnrichedSummary) => void;
+  onReopenClick: (id: string) => void;
   isNew?: boolean;
 };
 
@@ -37,7 +39,7 @@ function MaturityLabel({
 }) {
   if (isOpenEnded)
     return <span className="text-xs text-muted-foreground">Open-ended</span>;
-  if (effectiveStatus === "settled")
+  if (effectiveStatus === "settled" || effectiveStatus === "closed")
     return <span className="text-xs text-muted-foreground">—</span>;
   if (!maturityDate)
     return <span className="text-xs text-muted-foreground">—</span>;
@@ -71,7 +73,7 @@ function MaturityLabel({
   );
 }
 
-export const DepositCard = memo(function DepositCard({ summary, onSettleClick, onDeleteClick, onEditClick, onUnsettleClick, isNew }: Props) {
+export const DepositCard = memo(function DepositCard({ summary, onSettleClick, onDeleteClick, onEditClick, onUnsettleClick, onCloseClick, onReopenClick, isNew }: Props) {
   const { fmtCurrency } = useFormatterContext();
   const { deposit, bank, maturityDate, netInterest, effectiveStatus } = summary;
 
@@ -133,6 +135,21 @@ export const DepositCard = memo(function DepositCard({ summary, onSettleClick, o
                       <DropdownMenuItem onClick={() => onUnsettleClick(deposit.id)}>
                         <Undo2 />
                         Undo Settle
+                      </DropdownMenuItem>
+                    )}
+                    {effectiveStatus === "closed" && (
+                      <DropdownMenuItem onClick={() => onReopenClick(deposit.id)}>
+                        <RefreshCw />
+                        Reopen
+                      </DropdownMenuItem>
+                    )}
+                    {effectiveStatus === "active" && (
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => onCloseClick(summary)}
+                      >
+                        <X />
+                        {deposit.isOpenEnded ? "Close Account" : "Close Early"}
                       </DropdownMenuItem>
                     )}
                     <DropdownMenuItem onClick={() => onEditClick(deposit)}>

--- a/src/features/investments/components/InvestmentsShell.tsx
+++ b/src/features/investments/components/InvestmentsShell.tsx
@@ -13,6 +13,8 @@ export function InvestmentsShell() {
     highlightedId,
     handleSettle,
     handleUnsettle,
+    handleClose,
+    handleReopen,
     handleDelete,
     handleEdit,
     openWizard,
@@ -43,6 +45,8 @@ export function InvestmentsShell() {
             summaries={portfolio.summaries}
             onSettle={handleSettle}
             onUnsettle={handleUnsettle}
+            onClose={handleClose}
+            onReopen={handleReopen}
             onDelete={handleDelete}
             onEdit={handleEdit}
             onRollOver={openRollover}

--- a/src/features/investments/components/InvestmentsShell.tsx
+++ b/src/features/investments/components/InvestmentsShell.tsx
@@ -28,11 +28,16 @@ export function InvestmentsShell() {
         <Container className="py-6 space-y-stack-lg">
           <PageHeader
             title="Investments"
-            subtitle={
-              portfolio.summaries.length > 0
-                ? `${portfolio.summaries.length} deposit${portfolio.summaries.length !== 1 ? "s" : ""} tracked`
-                : "No investments yet"
-            }
+            subtitle={(() => {
+              const total = portfolio.summaries.length;
+              if (total === 0) return "No investments yet";
+              const active = portfolio.summaries.filter(
+                (s) => s.effectiveStatus === "active" || s.effectiveStatus === "matured",
+              ).length;
+              return active > 0 && active < total
+                ? `${active} active · ${total} total`
+                : `${total} deposit${total !== 1 ? "s" : ""} tracked`;
+            })()}
             action={{ onClick: () => openWizard() }}
             secondaryAction={
               portfolio.summaries.length > 0

--- a/src/features/investments/components/InvestmentsView.tsx
+++ b/src/features/investments/components/InvestmentsView.tsx
@@ -46,6 +46,7 @@ import { useFormatterContext } from "@/features/portfolio/context/PortfolioConte
 import { DepositCard } from "./DepositCard";
 import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 import { SettleConfirmDialog } from "./SettleConfirmDialog";
+import { CloseConfirmDialog } from "./CloseConfirmDialog";
 import { EmptyState } from "@/features/dashboard/components/EmptyState";
 import { LadderView } from "./LadderView";
 import { BankActiveSummary } from "./BankActiveSummary";
@@ -60,6 +61,8 @@ type Props = {
   summaries: EnrichedSummary[];
   onSettle: (id: string) => void;
   onUnsettle: (id: string) => void;
+  onClose: (id: string, closeDate: string) => void;
+  onReopen: (id: string) => void;
   onDelete: (id: string) => void;
   onEdit: (deposit: TimeDeposit) => void;
   onRollOver: (config: RolloverConfig) => void;
@@ -72,7 +75,8 @@ function statusSortWeight(s: EnrichedSummary): number {
   if (s.effectiveStatus === "matured") return 0;
   if (s.effectiveStatus === "active" && !s.deposit.isOpenEnded) return 1;
   if (s.effectiveStatus === "active" && s.deposit.isOpenEnded) return 2;
-  return 3; // settled
+  if (s.effectiveStatus === "settled") return 3;
+  return 4; // closed
 }
 
 function sortSummaries(list: EnrichedSummary[]): EnrichedSummary[] {
@@ -97,13 +101,14 @@ function sortSummaries(list: EnrichedSummary[]): EnrichedSummary[] {
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onEdit, onRollOver, highlightedId }: Props) {
+export function InvestmentsView({ summaries, onSettle, onUnsettle, onClose, onReopen, onDelete, onEdit, onRollOver, highlightedId }: Props) {
   const { fmtCurrency } = useFormatterContext();
   const columns = useMemo(() => createColumns(fmtCurrency), [fmtCurrency]);
   const [view, setView] = useState<"list" | "ladder">("list");
   const [showSettled, setShowSettled] = useState(false);
   const [bankFilter, setBankFilter] = useState("all");
   const [settleTarget, setSettleTarget] = useState<EnrichedSummary | null>(null);
+  const [closeTarget, setCloseTarget] = useState<EnrichedSummary | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<EnrichedSummary | null>(null);
   const [sorting, setSorting] = useState<SortingState>([{ id: "daysToMaturity", desc: false }]);
   const [summaryOpen, setSummaryOpen] = useState(false);
@@ -120,7 +125,7 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onE
   // Filtered summaries
   const filtered = useMemo(() => {
     let list = summaries;
-    if (!showSettled) list = list.filter((s) => s.effectiveStatus !== "settled");
+    if (!showSettled) list = list.filter((s) => s.effectiveStatus !== "settled" && s.effectiveStatus !== "closed");
     if (bankFilter !== "all") list = list.filter((s) => s.bank.id === bankFilter);
     return list;
   }, [summaries, showSettled, bankFilter]);
@@ -171,6 +176,11 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onE
           label: "Settled",
           items: sortedForCards.filter((s) => s.effectiveStatus === "settled"),
         },
+        {
+          key: "closed",
+          label: "Closed",
+          items: sortedForCards.filter((s) => s.effectiveStatus === "closed"),
+        },
       ].filter((g) => g.items.length > 0),
     [sortedForCards],
   );
@@ -178,6 +188,27 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onE
   const handleSettleClick = useCallback((summary: EnrichedSummary) => {
     setSettleTarget(summary);
   }, []);
+
+  const handleCloseClick = useCallback((summary: EnrichedSummary) => {
+    setCloseTarget(summary);
+  }, []);
+
+  const handleCloseConfirm = useCallback(
+    (id: string) => {
+      const name = closeTarget?.deposit.name ?? "";
+      const today = toISODate(new Date());
+      onClose(id, today);
+      setCloseTarget(null);
+      setAnnouncement(`${name} closed.`);
+      toast.success(`${name} closed`, {
+        action: {
+          label: "Undo",
+          onClick: () => onReopen(id),
+        },
+      });
+    },
+    [onClose, onReopen, closeTarget],
+  );
 
   const handleRollOverRequest = useCallback(
     (summary: EnrichedSummary) => {
@@ -243,6 +274,8 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onE
       onDelete: handleDeleteRequest,
       onEdit,
       onUnsettle,
+      onCloseClick: handleCloseClick,
+      onReopen,
     },
   });
 
@@ -277,7 +310,7 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onE
             size="default"
           />
           <Label htmlFor="show-settled" className="text-sm cursor-pointer select-none">
-            Show settled
+            Show closed / settled
           </Label>
         </div>
 
@@ -443,6 +476,8 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onE
                     onDeleteClick={handleDeleteRequest}
                     onEditClick={onEdit}
                     onUnsettleClick={onUnsettle}
+                    onCloseClick={handleCloseClick}
+                    onReopenClick={onReopen}
                     isNew={s.deposit.id === highlightedId}
                   />
                 ))}
@@ -461,6 +496,17 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onDelete, onE
         }}
         onConfirm={handleSettleConfirm}
         onRollOver={handleRollOverRequest}
+      />
+
+      {/* Close account dialog */}
+      <CloseConfirmDialog
+        summary={closeTarget}
+        closeDate={toISODate(new Date())}
+        open={closeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setCloseTarget(null);
+        }}
+        onConfirm={handleCloseConfirm}
       />
 
       {/* Delete dialog */}

--- a/src/features/investments/components/InvestmentsView.tsx
+++ b/src/features/investments/components/InvestmentsView.tsx
@@ -148,42 +148,30 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onClose, onRe
   // For card view: sorted filtered list
   const sortedForCards = useMemo(() => sortSummaries(filtered), [filtered]);
 
-  // Card view groups
-  const groups = useMemo(
-    () =>
+  // Card view groups — single pass instead of five filters
+  const groups = useMemo(() => {
+    const b: Record<string, EnrichedSummary[]> = {
+      matured: [], active: [], "open-ended": [], settled: [], closed: [],
+    };
+    for (const s of sortedForCards) {
+      if (s.effectiveStatus === "matured") b.matured.push(s);
+      else if (s.effectiveStatus === "active" && !s.deposit.isOpenEnded) b.active.push(s);
+      else if (s.effectiveStatus === "active") b["open-ended"].push(s);
+      else if (s.effectiveStatus === "settled") b.settled.push(s);
+      else b.closed.push(s);
+    }
+    return (
       [
-        {
-          key: "matured",
-          label: "Matured",
-          items: sortedForCards.filter((s) => s.effectiveStatus === "matured"),
-        },
-        {
-          key: "active",
-          label: "Active",
-          items: sortedForCards.filter(
-            (s) => s.effectiveStatus === "active" && !s.deposit.isOpenEnded,
-          ),
-        },
-        {
-          key: "open-ended",
-          label: "Open-ended",
-          items: sortedForCards.filter(
-            (s) => s.effectiveStatus === "active" && s.deposit.isOpenEnded,
-          ),
-        },
-        {
-          key: "settled",
-          label: "Settled",
-          items: sortedForCards.filter((s) => s.effectiveStatus === "settled"),
-        },
-        {
-          key: "closed",
-          label: "Closed",
-          items: sortedForCards.filter((s) => s.effectiveStatus === "closed"),
-        },
-      ].filter((g) => g.items.length > 0),
-    [sortedForCards],
-  );
+        { key: "matured", label: "Matured" },
+        { key: "active", label: "Active" },
+        { key: "open-ended", label: "Open-ended" },
+        { key: "settled", label: "Settled" },
+        { key: "closed", label: "Closed" },
+      ] as const
+    )
+      .map(({ key, label }) => ({ key, label, items: b[key] }))
+      .filter((g) => g.items.length > 0);
+  }, [sortedForCards]);
 
   const handleSettleClick = useCallback((summary: EnrichedSummary) => {
     setSettleTarget(summary);
@@ -194,10 +182,9 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onClose, onRe
   }, []);
 
   const handleCloseConfirm = useCallback(
-    (id: string) => {
+    (id: string, closeDate: string) => {
       const name = closeTarget?.deposit.name ?? "";
-      const today = toISODate(new Date());
-      onClose(id, today);
+      onClose(id, closeDate);
       setCloseTarget(null);
       setAnnouncement(`${name} closed.`);
       toast.success(`${name} closed`, {
@@ -242,19 +229,16 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onClose, onRe
     [onSettle, onUnsettle, settleTarget],
   );
 
-  const handleDeleteRequest = useCallback(
-    (id: string) => {
-      const target = summaries.find((s) => s.deposit.id === id) ?? null;
-      setDeleteTarget(target);
-    },
-    [summaries],
-  );
+  const handleDeleteRequest = useCallback((summary: EnrichedSummary) => {
+    setDeleteTarget(summary);
+  }, []);
 
   const handleDeleteConfirm = useCallback(
     (id: string) => {
       const name = deleteTarget?.deposit.name ?? "";
       onDelete(id);
       setDeleteTarget(null);
+      setAnnouncement(`${name} deleted.`);
       toast.success(`${name} deleted`);
     },
     [onDelete, deleteTarget],
@@ -310,7 +294,7 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onClose, onRe
             size="default"
           />
           <Label htmlFor="show-settled" className="text-sm cursor-pointer select-none">
-            Show closed / settled
+            Show inactive
           </Label>
         </div>
 
@@ -498,16 +482,18 @@ export function InvestmentsView({ summaries, onSettle, onUnsettle, onClose, onRe
         onRollOver={handleRollOverRequest}
       />
 
-      {/* Close account dialog */}
-      <CloseConfirmDialog
-        summary={closeTarget}
-        closeDate={toISODate(new Date())}
-        open={closeTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) setCloseTarget(null);
-        }}
-        onConfirm={handleCloseConfirm}
-      />
+      {/* Close account dialog — only mounts when a target is selected */}
+      {closeTarget !== null && (
+        <CloseConfirmDialog
+          summary={closeTarget}
+          closeDate={toISODate(new Date())}
+          open
+          onOpenChange={(open) => {
+            if (!open) setCloseTarget(null);
+          }}
+          onConfirm={handleCloseConfirm}
+        />
+      )}
 
       {/* Delete dialog */}
       <DeleteConfirmDialog

--- a/src/features/investments/components/LadderView.tsx
+++ b/src/features/investments/components/LadderView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useEffect, useRef } from "react";
-import { CircleArrowRight, CircleCheck, TriangleAlert } from "lucide-react";
+import { CircleAlert, CircleArrowRight, CircleCheck, TriangleAlert } from "lucide-react";
 import {
   parseLocalDate,
   differenceInCalendarDays,
@@ -34,7 +34,13 @@ function barClasses(s: EnrichedSummary): string {
   const rounded = s.deposit.isOpenEnded ? "rounded-l-bar rounded-r-none" : "rounded-bar";
   if (s.effectiveStatus === "settled") return cn(rounded, "bg-progress-success-fill");
   if (s.effectiveStatus === "matured") return cn(rounded, "bg-progress-warning-fill");
-  if (s.deposit.isOpenEnded) return cn(rounded, "bg-primary/40");
+  if (s.deposit.isOpenEnded) {
+    if (s.effectiveStatus === "closed") {
+      return cn(rounded, "bg-progress-alert-fill/50");
+    }
+    return cn(rounded, "bg-primary/40");
+  }
+  if (s.effectiveStatus === "closed") return cn(rounded, "bg-progress-alert-fill");
   return cn(rounded, "bg-primary");
 }
 
@@ -42,7 +48,13 @@ function barClasses(s: EnrichedSummary): string {
 function mobileElapsedClass(s: EnrichedSummary): string {
   if (s.effectiveStatus === "settled") return "bg-progress-success-fill";
   if (s.effectiveStatus === "matured") return "bg-progress-warning-fill";
-  if (s.deposit.isOpenEnded) return "bg-primary/50";
+  if (s.deposit.isOpenEnded) {
+    if (s.effectiveStatus === "closed") {
+      return "bg-progress-alert-fill/50";
+    }
+    return "bg-primary/50";
+  }
+  if (s.effectiveStatus === "closed") return "bg-progress-alert-fill";
   return "bg-primary";
 }
 
@@ -263,6 +275,9 @@ function DesktopLadder({
                     )}
                     {s.effectiveStatus === "matured" && widthPct > 2 && (
                       <TriangleAlert size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-black pointer-events-none" />
+                    )}
+                    {s.effectiveStatus === "closed" && widthPct > 2 && (
+                      <CircleAlert size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-black pointer-events-none" />
                     )}
                     {!s.maturityDate && widthPct > 2 && (
                       <CircleArrowRight size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-foreground pointer-events-none" />

--- a/src/features/investments/components/LadderView.tsx
+++ b/src/features/investments/components/LadderView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useEffect, useRef } from "react";
-import { CircleAlert, CircleArrowRight, CircleCheck, TriangleAlert } from "lucide-react";
+import { CircleArrowRight, CircleCheck, CircleX, TriangleAlert } from "lucide-react";
 import {
   parseLocalDate,
   differenceInCalendarDays,
@@ -277,7 +277,7 @@ function DesktopLadder({
                       <TriangleAlert size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-black pointer-events-none" />
                     )}
                     {s.effectiveStatus === "closed" && widthPct > 2 && (
-                      <CircleAlert size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-black pointer-events-none" />
+                      <CircleX size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-black pointer-events-none" />
                     )}
                     {!s.maturityDate && widthPct > 2 && (
                       <CircleArrowRight size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-foreground pointer-events-none" />

--- a/src/features/investments/components/SettleConfirmDialog.tsx
+++ b/src/features/investments/components/SettleConfirmDialog.tsx
@@ -34,7 +34,7 @@ export function SettleConfirmDialog({ summary, open, onOpenChange, onConfirm, on
         <AlertDialogHeader>
           <AlertDialogTitle>Settle {deposit.name}?</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="space-y-1 text-sm">
+            <div className="space-y-1 text-sm w-full">
               <div className="flex justify-between">
                 <span>Principal</span>
                 <span className="font-medium text-foreground">
@@ -57,7 +57,7 @@ export function SettleConfirmDialog({ summary, open, onOpenChange, onConfirm, on
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <Button variant="outline" onClick={() => onRollOver(summary)}>
-            Roll Over
+            Roll over
           </Button>
           <AlertDialogAction onClick={() => onConfirm(deposit.id)}>
             Settle {fmtCurrency(netTotal)}

--- a/src/features/investments/components/__tests__/CloseConfirmDialog.test.tsx
+++ b/src/features/investments/components/__tests__/CloseConfirmDialog.test.tsx
@@ -79,7 +79,7 @@ describe("CloseConfirmDialog — time deposit (early close)", () => {
     expect(screen.getByText(/31d remaining/i)).toBeInTheDocument();
   });
 
-  it("shows 'Close Account' button", () => {
+  it("shows 'Close account' button", () => {
     renderDialog();
     expect(screen.getByRole("button", { name: /close account/i })).toBeInTheDocument();
   });
@@ -100,11 +100,22 @@ describe("CloseConfirmDialog — time deposit (early close)", () => {
     expect(screen.getByText(/net proceeds/i)).toBeInTheDocument();
   });
 
-  it("calls onConfirm with the deposit id when confirmed", () => {
+  it("calls onConfirm with the deposit id and closeDate when confirmed", () => {
     const onConfirm = vi.fn();
-    renderDialog({ onConfirm });
+    renderDialog({ onConfirm, closeDate: "2025-12-01" });
     fireEvent.click(screen.getByRole("button", { name: /close account/i }));
-    expect(onConfirm).toHaveBeenCalledWith("dep-1");
+    expect(onConfirm).toHaveBeenCalledWith("dep-1", "2025-12-01");
+  });
+
+  it("shows correct net proceeds for a 61-day close", () => {
+    // startDate 2025-10-01, closeDate 2025-12-01 = 61 days
+    // gross = 100000 * 0.06 * (61/365) ≈ 1002.74, net ≈ 802.19, netProceeds ≈ 100802
+    renderDialog({
+      summary: makeSummary(makeDeposit({ startDate: "2025-10-01" }), "2026-01-01"),
+      closeDate: "2025-12-01",
+    });
+    const row = screen.getByText(/net proceeds/i).closest("div");
+    expect(row).toHaveTextContent(/100[,. ]?80[23]/);
   });
 
   it("calls onOpenChange(false) when cancel is clicked", () => {
@@ -133,22 +144,5 @@ describe("CloseConfirmDialog — open-ended savings (close account)", () => {
       closeDate: "2025-12-01",
     });
     expect(screen.getByText(/close savings account\?/i)).toBeInTheDocument();
-  });
-});
-
-describe("CloseConfirmDialog — null summary", () => {
-  it("renders nothing when summary is null", () => {
-    const { container } = render(
-      <PortfolioProvider>
-        <CloseConfirmDialog
-          summary={null}
-          closeDate="2025-12-01"
-          open={true}
-          onOpenChange={vi.fn()}
-          onConfirm={vi.fn()}
-        />
-      </PortfolioProvider>,
-    );
-    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/features/investments/components/__tests__/CloseConfirmDialog.test.tsx
+++ b/src/features/investments/components/__tests__/CloseConfirmDialog.test.tsx
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CloseConfirmDialog } from "../CloseConfirmDialog";
+import { PortfolioProvider } from "@/features/portfolio/context/PortfolioContext";
+import type { EnrichedSummary } from "@/features/portfolio/hooks/usePortfolioData";
+import type { Bank, TimeDeposit } from "@/types";
+
+const bank: Bank = { id: "bank-1", name: "Test Bank", taxRate: 0.2 };
+
+function makeDeposit(overrides: Partial<TimeDeposit> = {}): TimeDeposit {
+  return {
+    id: "dep-1",
+    bankId: "bank-1",
+    name: "3-Month TD",
+    principal: 100_000,
+    startDate: "2025-10-01",
+    termMonths: 3,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    flatRate: 0.06,
+    tiers: [{ upTo: null, rate: 0.06 }],
+    payoutFrequency: "maturity",
+    dayCountConvention: 365,
+    isOpenEnded: false,
+    status: "active",
+    ...overrides,
+  };
+}
+
+function makeSummary(deposit: TimeDeposit, maturityDate: string | null): EnrichedSummary {
+  return {
+    deposit,
+    bank,
+    maturityDate,
+    grossInterest: 1_500,
+    netInterest: 1_200,
+    grossTotal: 101_500,
+    netTotal: 101_200,
+    effectiveStatus: "active",
+  };
+}
+
+function renderDialog(props: Partial<Parameters<typeof CloseConfirmDialog>[0]> = {}) {
+  const deposit = props.summary?.deposit ?? makeDeposit();
+  const maturityDate = props.summary?.maturityDate ?? "2026-01-01";
+  const summary = props.summary ?? makeSummary(deposit, maturityDate);
+
+  const defaults = {
+    summary,
+    closeDate: "2025-12-01",
+    open: true,
+    onOpenChange: vi.fn(),
+    onConfirm: vi.fn(),
+  };
+
+  return render(
+    <PortfolioProvider>
+      <CloseConfirmDialog {...defaults} {...props} />
+    </PortfolioProvider>,
+  );
+}
+
+describe("CloseConfirmDialog — time deposit (early close)", () => {
+  it("shows maturity warning when closing before maturity", () => {
+    renderDialog({
+      summary: makeSummary(makeDeposit(), "2026-01-01"),
+      closeDate: "2025-12-01",
+    });
+    expect(screen.getByText(/closing before maturity/i)).toBeInTheDocument();
+  });
+
+  it("shows days remaining in the warning", () => {
+    renderDialog({
+      summary: makeSummary(makeDeposit(), "2026-01-01"),
+      closeDate: "2025-12-01",
+    });
+    // 31 days remaining (Dec 1 → Jan 1)
+    expect(screen.getByText(/31d remaining/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Close Account' button", () => {
+    renderDialog();
+    expect(screen.getByRole("button", { name: /close account/i })).toBeInTheDocument();
+  });
+
+  it("shows principal in the breakdown", () => {
+    renderDialog({ summary: makeSummary(makeDeposit({ principal: 50_000 }), "2026-01-01") });
+    // The dialog renders formatted currency — just check principal label is present
+    expect(screen.getByText("Principal")).toBeInTheDocument();
+  });
+
+  it("shows 'Accrued net interest' in the breakdown", () => {
+    renderDialog();
+    expect(screen.getByText(/accrued net interest/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Net proceeds' totals row", () => {
+    renderDialog();
+    expect(screen.getByText(/net proceeds/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm with the deposit id when confirmed", () => {
+    const onConfirm = vi.fn();
+    renderDialog({ onConfirm });
+    fireEvent.click(screen.getByRole("button", { name: /close account/i }));
+    expect(onConfirm).toHaveBeenCalledWith("dep-1");
+  });
+
+  it("calls onOpenChange(false) when cancel is clicked", () => {
+    const onOpenChange = vi.fn();
+    renderDialog({ onOpenChange });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("CloseConfirmDialog — open-ended savings (close account)", () => {
+  it("does NOT show the maturity warning for open-ended deposits", () => {
+    renderDialog({
+      summary: makeSummary(
+        makeDeposit({ isOpenEnded: true }),
+        null, // open-ended has no maturityDate
+      ),
+      closeDate: "2025-12-01",
+    });
+    expect(screen.queryByText(/closing before maturity/i)).not.toBeInTheDocument();
+  });
+
+  it("uses 'Close account?' (not 'early') in the dialog title", () => {
+    renderDialog({
+      summary: makeSummary(makeDeposit({ name: "Savings Account", isOpenEnded: true }), null),
+      closeDate: "2025-12-01",
+    });
+    expect(screen.getByText(/close savings account\?/i)).toBeInTheDocument();
+  });
+});
+
+describe("CloseConfirmDialog — null summary", () => {
+  it("renders nothing when summary is null", () => {
+    const { container } = render(
+      <PortfolioProvider>
+        <CloseConfirmDialog
+          summary={null}
+          closeDate="2025-12-01"
+          open={true}
+          onOpenChange={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </PortfolioProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/features/investments/components/__tests__/InvestmentsView.test.tsx
+++ b/src/features/investments/components/__tests__/InvestmentsView.test.tsx
@@ -183,7 +183,7 @@ describe("InvestmentsView — reopen", () => {
     renderView({ summaries: [closedSummary], onReopen });
 
     // Closed deposits are hidden by default — toggle "Show inactive" first
-    fireEvent.click(screen.getByRole("switch", { name: /show closed \/ settled/i }));
+    fireEvent.click(screen.getByRole("switch", { name: /show inactive/i }));
 
     fireEvent.click(screen.getByRole("button", { name: /reopen my bank td/i }));
     expect(onReopen).toHaveBeenCalledWith("dep-1");

--- a/src/features/investments/components/__tests__/InvestmentsView.test.tsx
+++ b/src/features/investments/components/__tests__/InvestmentsView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { InvestmentsView } from "../InvestmentsView";
 import { PortfolioProvider } from "@/features/portfolio/context/PortfolioContext";
 import type { EnrichedSummary } from "@/features/portfolio/hooks/usePortfolioData";
@@ -22,7 +22,7 @@ vi.mock("../DepositCard", () => ({
   }: {
     summary: EnrichedSummary;
     onSettleClick: (s: EnrichedSummary) => void;
-    onDeleteClick: (id: string) => void;
+    onDeleteClick: (s: EnrichedSummary) => void;
     onUnsettleClick: (id: string) => void;
     onCloseClick: (s: EnrichedSummary) => void;
     onReopenClick: (id: string) => void;
@@ -38,7 +38,7 @@ vi.mock("../DepositCard", () => ({
       </button>
       <button
         aria-label={`Delete ${summary.deposit.name}`}
-        onClick={() => onDeleteClick(summary.deposit.id)}
+        onClick={() => onDeleteClick(summary)}
       >
         Delete
       </button>
@@ -123,9 +123,9 @@ describe("InvestmentsView — settle toast", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /settle my bank td/i }));
 
-    // The dialog confirm button text includes the formatted total — find it via the dialog
-    const allSettle = screen.getAllByRole("button", { name: /settle/i });
-    fireEvent.click(allSettle[allSettle.length - 1]);
+    // Scope to the alertdialog so the query is resilient to other "settle" buttons
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /settle/i }));
 
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(
@@ -182,8 +182,8 @@ describe("InvestmentsView — reopen", () => {
     };
     renderView({ summaries: [closedSummary], onReopen });
 
-    // Closed deposits are hidden by default — toggle "Show closed / settled" first
-    fireEvent.click(screen.getByRole("switch"));
+    // Closed deposits are hidden by default — toggle "Show inactive" first
+    fireEvent.click(screen.getByRole("switch", { name: /show closed \/ settled/i }));
 
     fireEvent.click(screen.getByRole("button", { name: /reopen my bank td/i }));
     expect(onReopen).toHaveBeenCalledWith("dep-1");
@@ -214,5 +214,58 @@ describe("InvestmentsView — delete toast", () => {
       expect(toast.success).toHaveBeenCalledWith("My Bank TD deleted");
     });
     expect(onDelete).toHaveBeenCalledWith("dep-1");
+  });
+});
+
+// ─── aria-live announcements ──────────────────────────────────────────────────
+
+describe("InvestmentsView — aria-live region", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("announces settle confirmation to screen readers", async () => {
+    renderView();
+    fireEvent.click(screen.getByRole("button", { name: /settle my bank td/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /settle/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/marked as settled/i);
+    });
+  });
+
+  it("announces close confirmation to screen readers", async () => {
+    const activeSummary: EnrichedSummary = { ...summary, effectiveStatus: "active" };
+    renderView({ summaries: [activeSummary] });
+    fireEvent.click(screen.getByRole("button", { name: /close my bank td/i }));
+    const confirmBtn = await screen.findByRole("button", { name: /close account/i });
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/closed/i);
+    });
+  });
+
+  it("announces delete confirmation to screen readers", async () => {
+    renderView();
+    fireEvent.click(screen.getByRole("button", { name: /delete my bank td/i }));
+    const confirmBtn = await screen.findByRole("button", { name: /delete my bank td/i });
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/deleted/i);
+    });
+  });
+});
+
+// ─── Empty states ─────────────────────────────────────────────────────────────
+
+describe("InvestmentsView — empty states", () => {
+  it("shows empty state when no summaries are provided", () => {
+    renderView({ summaries: [] });
+    expect(screen.getByText(/no investments tracked yet/i)).toBeInTheDocument();
+  });
+
+  it("renders no dialog when no deposit is targeted for close", () => {
+    renderView();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 });

--- a/src/features/investments/components/__tests__/InvestmentsView.test.tsx
+++ b/src/features/investments/components/__tests__/InvestmentsView.test.tsx
@@ -9,7 +9,7 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-// Mock DepositCard to expose settle/delete as plain buttons.
+// Mock DepositCard to expose settle/delete/close/reopen as plain buttons.
 // This isolates InvestmentsView's handler→toast logic from DepositCard's
 // Radix DropdownMenu, which requires real pointer events to open in jsdom.
 vi.mock("../DepositCard", () => ({
@@ -17,11 +17,15 @@ vi.mock("../DepositCard", () => ({
     summary,
     onSettleClick,
     onDeleteClick,
+    onCloseClick,
+    onReopenClick,
   }: {
     summary: EnrichedSummary;
     onSettleClick: (s: EnrichedSummary) => void;
     onDeleteClick: (id: string) => void;
     onUnsettleClick: (id: string) => void;
+    onCloseClick: (s: EnrichedSummary) => void;
+    onReopenClick: (id: string) => void;
     onEditClick: (deposit: TimeDeposit) => void;
     isNew?: boolean;
   }) => (
@@ -37,6 +41,18 @@ vi.mock("../DepositCard", () => ({
         onClick={() => onDeleteClick(summary.deposit.id)}
       >
         Delete
+      </button>
+      <button
+        aria-label={`Close ${summary.deposit.name}`}
+        onClick={() => onCloseClick(summary)}
+      >
+        Close
+      </button>
+      <button
+        aria-label={`Reopen ${summary.deposit.name}`}
+        onClick={() => onReopenClick(summary.deposit.id)}
+      >
+        Reopen
       </button>
     </div>
   ),
@@ -79,6 +95,8 @@ function renderView(overrides?: Partial<Parameters<typeof InvestmentsView>[0]>) 
     summaries: [summary],
     onSettle: vi.fn(),
     onUnsettle: vi.fn(),
+    onClose: vi.fn(),
+    onReopen: vi.fn(),
     onDelete: vi.fn(),
     onEdit: vi.fn(),
     onRollOver: vi.fn(),
@@ -116,6 +134,59 @@ describe("InvestmentsView — settle toast", () => {
       );
     });
     expect(onSettle).toHaveBeenCalledWith("dep-1");
+  });
+});
+
+// ─── Close ────────────────────────────────────────────────────────────────────
+
+describe("InvestmentsView — close toast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows "{name} closed" toast after confirming close', async () => {
+    const { toast } = await import("sonner");
+    const onClose = vi.fn();
+    const activeSummary: EnrichedSummary = { ...summary, effectiveStatus: "active" };
+    renderView({ summaries: [activeSummary], onClose });
+
+    fireEvent.click(screen.getByRole("button", { name: /close my bank td/i }));
+
+    // Confirm in the CloseConfirmDialog
+    const confirmBtn = await screen.findByRole("button", { name: /close account/i });
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "My Bank TD closed",
+        expect.objectContaining({ action: expect.objectContaining({ label: "Undo" }) }),
+      );
+    });
+    expect(onClose).toHaveBeenCalledWith("dep-1", expect.any(String));
+  });
+});
+
+// ─── Reopen ───────────────────────────────────────────────────────────────────
+
+describe("InvestmentsView — reopen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls onReopen with deposit id when reopen button is clicked", () => {
+    const onReopen = vi.fn();
+    const closedSummary: EnrichedSummary = {
+      ...summary,
+      deposit: { ...deposit, status: "closed", closeDate: "2025-11-01" },
+      effectiveStatus: "closed",
+    };
+    renderView({ summaries: [closedSummary], onReopen });
+
+    // Closed deposits are hidden by default — toggle "Show closed / settled" first
+    fireEvent.click(screen.getByRole("switch"));
+
+    fireEvent.click(screen.getByRole("button", { name: /reopen my bank td/i }));
+    expect(onReopen).toHaveBeenCalledWith("dep-1");
   });
 });
 

--- a/src/features/investments/components/columns.tsx
+++ b/src/features/investments/components/columns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ColumnDef, type Column, type RowData } from "@tanstack/react-table";
-import { MoreHorizontal, ArrowUp, ArrowDown, ChevronsUpDown, Pencil, Trash, Undo2 } from "lucide-react";
+import { MoreHorizontal, ArrowUp, ArrowDown, ChevronsUpDown, Pencil, Trash, Undo2, X, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import {
@@ -23,6 +23,8 @@ declare module "@tanstack/react-table" {
     onDelete: (id: string) => void;
     onEdit: (deposit: TimeDeposit) => void;
     onUnsettle: (id: string) => void;
+    onCloseClick: (summary: EnrichedSummary) => void;
+    onReopen: (id: string) => void;
   }
 }
 
@@ -160,7 +162,7 @@ export function createColumns(
     {
       id: "daysToMaturity",
       accessorFn: (row) => {
-        if (!row.maturityDate || row.deposit.isOpenEnded || row.effectiveStatus === "settled")
+        if (!row.maturityDate || row.deposit.isOpenEnded || row.effectiveStatus === "settled" || row.effectiveStatus === "closed")
           return null;
         const today = new Date();
         today.setHours(0, 0, 0, 0);
@@ -173,7 +175,7 @@ export function createColumns(
         today.setHours(0, 0, 0, 0);
 
         const getVal = (s: EnrichedSummary): number => {
-          if (!s.maturityDate || s.deposit.isOpenEnded || s.effectiveStatus === "settled")
+          if (!s.maturityDate || s.deposit.isOpenEnded || s.effectiveStatus === "settled" || s.effectiveStatus === "closed")
             return Infinity;
           return differenceInCalendarDays(parseLocalDate(s.maturityDate), today);
         };
@@ -182,7 +184,7 @@ export function createColumns(
       },
       cell: ({ row }) => {
         const { maturityDate, deposit, effectiveStatus } = row.original;
-        if (deposit.isOpenEnded || effectiveStatus === "settled")
+        if (deposit.isOpenEnded || effectiveStatus === "settled" || effectiveStatus === "closed")
           return <span className="text-muted-foreground">—</span>;
         return <DaysCell maturityDate={maturityDate} />;
       },
@@ -254,7 +256,7 @@ export function createColumns(
       cell: ({ row, table }) => {
         const summary = row.original;
         const { effectiveStatus, deposit } = summary;
-        const { onSettleClick, onDelete, onEdit, onUnsettle } = table.options.meta!;
+        const { onSettleClick, onDelete, onEdit, onUnsettle, onCloseClick, onReopen } = table.options.meta!;
 
         return (
           <div className="flex items-center justify-end">
@@ -291,10 +293,25 @@ export function createColumns(
                     Undo Settle
                   </DropdownMenuItem>
                 )}
+                {effectiveStatus === "closed" && (
+                  <DropdownMenuItem onClick={() => onReopen(deposit.id)}>
+                    <RefreshCw />
+                    Reopen
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem onClick={() => onEdit(deposit)}>
                   <Pencil />
                   Edit
                 </DropdownMenuItem>
+                {effectiveStatus === "active" && (
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onClick={() => onCloseClick(summary)}
+                  >
+                    <X />
+                    {deposit.isOpenEnded ? "Close Account" : "Close Early"}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   variant="destructive"
                   onClick={() => onDelete(deposit.id)}

--- a/src/features/investments/components/columns.tsx
+++ b/src/features/investments/components/columns.tsx
@@ -1,15 +1,9 @@
 "use client";
 
 import { type ColumnDef, type Column, type RowData } from "@tanstack/react-table";
-import { MoreHorizontal, ArrowUp, ArrowDown, ChevronsUpDown, Pencil, Trash, Undo2, X, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { ArrowUp, ArrowDown, ChevronsUpDown } from "lucide-react";
 import { StatusBadge } from "@/components/ui/StatusBadge";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { DepositActions } from "./DepositActions";
 import { formatDate, differenceInCalendarDays, parseLocalDate } from "@/lib/domain/date";
 import type { EnrichedSummary } from "@/features/portfolio/hooks/usePortfolioData";
 import type { TimeDeposit } from "@/types";
@@ -20,7 +14,7 @@ declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface TableMeta<TData extends RowData> {
     onSettleClick: (summary: EnrichedSummary) => void;
-    onDelete: (id: string) => void;
+    onDelete: (summary: EnrichedSummary) => void;
     onEdit: (deposit: TimeDeposit) => void;
     onUnsettle: (id: string) => void;
     onCloseClick: (summary: EnrichedSummary) => void;
@@ -28,7 +22,13 @@ declare module "@tanstack/react-table" {
   }
 }
 
-// ─── Sortable header component ────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function localToday(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
 
 function SortableHeader({ column, label }: { column: Column<EnrichedSummary>; label: string }) {
   const sorted = column.getIsSorted();
@@ -46,23 +46,11 @@ function SortableHeader({ column, label }: { column: Column<EnrichedSummary>; la
   );
 }
 
-// ─── Days-to-maturity helper ──────────────────────────────────────────────────
-
-function DaysCell({ maturityDate }: { maturityDate: string | null }) {
-  if (!maturityDate) return <span className="text-muted-foreground">—</span>;
-
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const days = differenceInCalendarDays(parseLocalDate(maturityDate), today);
-
+function DaysCell({ days }: { days: number }) {
   if (days > 30) return <span>{days}d</span>;
-  if (days > 0)
-    return <span className="font-medium text-status-warning-fg">{days}d</span>;
-  if (days === 0)
-    return <span className="font-medium text-status-warning-fg">Today</span>;
-  return (
-    <span className="font-medium text-status-warning-fg">{Math.abs(days)}d ago</span>
-  );
+  if (days > 0) return <span className="font-medium text-status-warning-fg">{days}d</span>;
+  if (days === 0) return <span className="font-medium text-status-warning-fg">Today</span>;
+  return <span className="font-medium text-status-warning-fg">{Math.abs(days)}d ago</span>;
 }
 
 // ─── Column definitions ────────────────────────────────────────────────────────
@@ -146,7 +134,7 @@ export function createColumns(
     // 4. Maturity date
     {
       id: "maturityDate",
-      accessorFn: (row) => row.maturityDate ?? "",
+      accessorFn: (row) => row.maturityDate ?? null,
       header: ({ column }) => <SortableHeader column={column} label="Matures" />,
       enableSorting: true,
       sortingFn: "alphanumeric",
@@ -164,29 +152,25 @@ export function createColumns(
       accessorFn: (row) => {
         if (!row.maturityDate || row.deposit.isOpenEnded || row.effectiveStatus === "settled" || row.effectiveStatus === "closed")
           return null;
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        return differenceInCalendarDays(parseLocalDate(row.maturityDate), today);
+        return differenceInCalendarDays(parseLocalDate(row.maturityDate), localToday());
       },
       header: ({ column }) => <SortableHeader column={column} label="Days left" />,
       enableSorting: true,
       sortingFn: (a, b) => {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-
         const getVal = (s: EnrichedSummary): number => {
           if (!s.maturityDate || s.deposit.isOpenEnded || s.effectiveStatus === "settled" || s.effectiveStatus === "closed")
             return Infinity;
-          return differenceInCalendarDays(parseLocalDate(s.maturityDate), today);
+          return differenceInCalendarDays(parseLocalDate(s.maturityDate), localToday());
         };
-
         return getVal(a.original) - getVal(b.original);
       },
       cell: ({ row }) => {
-        const { maturityDate, deposit, effectiveStatus } = row.original;
+        const { deposit, effectiveStatus } = row.original;
         if (deposit.isOpenEnded || effectiveStatus === "settled" || effectiveStatus === "closed")
           return <span className="text-muted-foreground">—</span>;
-        return <DaysCell maturityDate={maturityDate} />;
+        const days = row.getValue<number | null>("daysToMaturity");
+        if (days === null) return <span className="text-muted-foreground">—</span>;
+        return <DaysCell days={days} />;
       },
     },
 
@@ -198,7 +182,7 @@ export function createColumns(
       enableSorting: true,
       sortingFn: "basic",
       cell: ({ row }) => {
-        return <span className="text-accent-fg font-semibold">{fmtCurrency(row.original.netInterest)}</span>
+        return <span className="text-accent-fg font-semibold">{fmtCurrency(row.original.netInterest)}</span>;
       },
       footer: ({ table }) => {
         const total = table
@@ -239,9 +223,11 @@ export function createColumns(
       enableSorting: true,
       sortingFn: (a, b) => {
         const weight = (s: EnrichedSummary) => {
-          if (s.effectiveStatus === "matured") return 0;
-          if (s.effectiveStatus === "active") return 1;
-          return 2;
+          if (s.effectiveStatus === "matured")  return 0;
+          if (s.effectiveStatus === "active")   return 1;
+          if (s.effectiveStatus === "settled")  return 2;
+          if (s.effectiveStatus === "closed")   return 3;
+          return 4;
         };
         return weight(a.original) - weight(b.original);
       },
@@ -255,73 +241,19 @@ export function createColumns(
       enableSorting: false,
       cell: ({ row, table }) => {
         const summary = row.original;
-        const { effectiveStatus, deposit } = summary;
-        const { onSettleClick, onDelete, onEdit, onUnsettle, onCloseClick, onReopen } = table.options.meta!;
+        const { onSettleClick, onDelete, onEdit, onUnsettle, onCloseClick, onReopen } =
+          table.options.meta!;
 
         return (
-          <div className="flex items-center justify-end">
-            {effectiveStatus === "matured" && (
-              <Button
-                size="sm"
-                variant="outline"
-                className="rounded-r-none"
-                onClick={() => onSettleClick(summary)}
-                aria-label={`Settle ${deposit.name}`}
-              >
-                Settle
-              </Button>
-            )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className={
-                    effectiveStatus === "matured"
-                      ? "rounded-l-none border-l-0 px-2"
-                      : "px-2"
-                  }
-                  aria-label={`More options for ${deposit.name}`}
-                >
-                  <MoreHorizontal className="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {effectiveStatus === "settled" && (
-                  <DropdownMenuItem onClick={() => onUnsettle(deposit.id)}>
-                    <Undo2 />
-                    Undo Settle
-                  </DropdownMenuItem>
-                )}
-                {effectiveStatus === "closed" && (
-                  <DropdownMenuItem onClick={() => onReopen(deposit.id)}>
-                    <RefreshCw />
-                    Reopen
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem onClick={() => onEdit(deposit)}>
-                  <Pencil />
-                  Edit
-                </DropdownMenuItem>
-                {effectiveStatus === "active" && (
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={() => onCloseClick(summary)}
-                  >
-                    <X />
-                    {deposit.isOpenEnded ? "Close Account" : "Close Early"}
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem
-                  variant="destructive"
-                  onClick={() => onDelete(deposit.id)}
-                >
-                  <Trash />
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          <DepositActions
+            summary={summary}
+            onSettle={onSettleClick}
+            onUnsettle={onUnsettle}
+            onClose={onCloseClick}
+            onReopen={onReopen}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
         );
       },
     },

--- a/src/features/portfolio/context/PortfolioContext.tsx
+++ b/src/features/portfolio/context/PortfolioContext.tsx
@@ -81,6 +81,8 @@ interface PortfolioContextValue {
   handleSave: (deposit: TimeDeposit) => void;
   handleSettle: (id: string) => void;
   handleUnsettle: (id: string) => void;
+  handleClose: (id: string, closeDate: string) => void;
+  handleReopen: (id: string) => void;
   handleRollOver: (oldId: string, newDeposit: TimeDeposit) => void;
   handleDelete: (id: string) => void;
   handleEdit: (deposit: TimeDeposit) => void;
@@ -253,6 +255,48 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
     [isDemoMode, setDeposits],
   );
 
+  const handleClose = useCallback(
+    (id: string, closeDate: string) => {
+      if (isDemoMode) {
+        setLiveDemoDeposits((prev) =>
+          prev.map((d) => (d.id === id ? { ...d, status: "closed" as const, closeDate } : d)),
+        );
+      } else {
+        setDeposits((prev) =>
+          prev.map((d) => (d.id === id ? { ...d, status: "closed" as const, closeDate } : d)),
+        );
+      }
+      setHighlightedId(id);
+      setTimeout(() => setHighlightedId(null), 2500);
+    },
+    [isDemoMode, setDeposits],
+  );
+
+  const handleReopen = useCallback(
+    (id: string) => {
+      if (isDemoMode) {
+        setLiveDemoDeposits((prev) =>
+          prev.map((d) => {
+            if (d.id !== id) return d;
+            const { closeDate: _, ...rest } = d;
+            return { ...rest, status: "active" as const };
+          }),
+        );
+      } else {
+        setDeposits((prev) =>
+          prev.map((d) => {
+            if (d.id !== id) return d;
+            const { closeDate: _, ...rest } = d;
+            return { ...rest, status: "active" as const };
+          }),
+        );
+      }
+      setHighlightedId(id);
+      setTimeout(() => setHighlightedId(null), 2500);
+    },
+    [isDemoMode, setDeposits],
+  );
+
   const handleRollOver = useCallback(
     (oldId: string, newDeposit: TimeDeposit) => {
       if (isDemoMode) {
@@ -340,6 +384,8 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       handleSave,
       handleSettle,
       handleUnsettle,
+      handleClose,
+      handleReopen,
       handleRollOver,
       handleDelete,
       handleEdit,
@@ -372,6 +418,8 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       handleSave,
       handleSettle,
       handleUnsettle,
+      handleClose,
+      handleReopen,
       handleRollOver,
       handleDelete,
       handleEdit,

--- a/src/features/portfolio/context/PortfolioContext.tsx
+++ b/src/features/portfolio/context/PortfolioContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { usePersistedDeposits } from "@/lib/hooks/usePersistedDeposits";
 import { useLocalStorage } from "@/lib/hooks/useLocalStorage";
 import { usePreferences } from "@/lib/hooks/usePreferences";
@@ -131,6 +131,7 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
   const [rolloverConfig, setRolloverConfig] = useState<RolloverConfig | null>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const [exportAiOpen, setExportAiOpen] = useState(false);
+  const highlightTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // When demo mode is restored from persisted storage, re-populate demo deposits.
   // setState inside an effect is intentional here: we're syncing React state from
@@ -200,131 +201,99 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
     setRolloverConfig(null);
   }, []);
 
+  // ─── Shared mutation helpers ───────────────────────────────────────────────
+
+  // Always uses the functional updater form to avoid stale-closure captures.
+  const updateDeposits = useCallback(
+    (fn: (prev: TimeDeposit[]) => TimeDeposit[]) => {
+      if (isDemoMode) setLiveDemoDeposits(fn);
+      else setDeposits(fn);
+    },
+    [isDemoMode, setDeposits],
+  );
+
+  // Clears any pending highlight timer before setting a new one, preventing
+  // rapid-successive mutations from racing and wiping each other's highlight.
+  const highlight = useCallback((id: string) => {
+    setHighlightedId(id);
+    if (highlightTimer.current) clearTimeout(highlightTimer.current);
+    highlightTimer.current = setTimeout(() => setHighlightedId(null), 2500);
+  }, []);
+
   // ─── Deposit mutations ─────────────────────────────────────────────────────
 
   const handleSave = useCallback(
     (deposit: TimeDeposit) => {
-      if (isDemoMode) {
-        setLiveDemoDeposits((prev) =>
-          editTarget
-            ? prev.map((d) => (d.id === deposit.id ? { ...deposit, status: editTarget.status } : d))
-            : [...prev, deposit],
-        );
-      } else {
-        setDeposits(
-          editTarget
-            ? storedDeposits.map((d) => (d.id === deposit.id ? { ...deposit, status: editTarget.status } : d))
-            : [...storedDeposits, deposit],
-        );
-      }
-      setHighlightedId(deposit.id);
-      setTimeout(() => setHighlightedId(null), 2500);
+      updateDeposits((prev) =>
+        editTarget
+          ? prev.map((d) => (d.id === deposit.id ? { ...deposit, status: editTarget.status } : d))
+          : [...prev, deposit],
+      );
+      highlight(deposit.id);
     },
-    [isDemoMode, storedDeposits, setDeposits, editTarget],
+    [updateDeposits, editTarget, highlight],
   );
 
   const handleSettle = useCallback(
     (id: string) => {
-      if (isDemoMode) {
-        setLiveDemoDeposits((prev) =>
-          prev.map((d) => (d.id === id ? { ...d, status: "settled" as const } : d)),
-        );
-      } else {
-        setDeposits(storedDeposits.map((d) => (d.id === id ? { ...d, status: "settled" as const } : d)));
-      }
-      setHighlightedId(id);
-      setTimeout(() => setHighlightedId(null), 2500);
+      updateDeposits((prev) =>
+        prev.map((d) => (d.id === id ? { ...d, status: "settled" as const } : d)),
+      );
+      highlight(id);
     },
-    [isDemoMode, storedDeposits, setDeposits],
+    [updateDeposits, highlight],
   );
 
   const handleUnsettle = useCallback(
     (id: string) => {
-      if (isDemoMode) {
-        setLiveDemoDeposits((prev) =>
-          prev.map((d) => (d.id === id ? { ...d, status: "matured" as const } : d)),
-        );
-      } else {
-        setDeposits((prev) =>
-          prev.map((d) => (d.id === id ? { ...d, status: "matured" as const } : d)),
-        );
-      }
-      setHighlightedId(id);
-      setTimeout(() => setHighlightedId(null), 2500);
+      updateDeposits((prev) =>
+        prev.map((d) => (d.id === id ? { ...d, status: "matured" as const } : d)),
+      );
+      highlight(id);
     },
-    [isDemoMode, setDeposits],
+    [updateDeposits, highlight],
   );
 
   const handleClose = useCallback(
     (id: string, closeDate: string) => {
-      if (isDemoMode) {
-        setLiveDemoDeposits((prev) =>
-          prev.map((d) => (d.id === id ? { ...d, status: "closed" as const, closeDate } : d)),
-        );
-      } else {
-        setDeposits((prev) =>
-          prev.map((d) => (d.id === id ? { ...d, status: "closed" as const, closeDate } : d)),
-        );
-      }
-      setHighlightedId(id);
-      setTimeout(() => setHighlightedId(null), 2500);
+      updateDeposits((prev) =>
+        prev.map((d) => (d.id === id ? { ...d, status: "closed" as const, closeDate } : d)),
+      );
+      highlight(id);
     },
-    [isDemoMode, setDeposits],
+    [updateDeposits, highlight],
   );
 
   const handleReopen = useCallback(
     (id: string) => {
-      if (isDemoMode) {
-        setLiveDemoDeposits((prev) =>
-          prev.map((d) => {
-            if (d.id !== id) return d;
-            const { closeDate: _, ...rest } = d;
-            return { ...rest, status: "active" as const };
-          }),
-        );
-      } else {
-        setDeposits((prev) =>
-          prev.map((d) => {
-            if (d.id !== id) return d;
-            const { closeDate: _, ...rest } = d;
-            return { ...rest, status: "active" as const };
-          }),
-        );
-      }
-      setHighlightedId(id);
-      setTimeout(() => setHighlightedId(null), 2500);
+      updateDeposits((prev) =>
+        prev.map((d) => {
+          if (d.id !== id) return d;
+          const { closeDate: _, ...rest } = d;
+          return { ...rest, status: "active" as const };
+        }),
+      );
+      highlight(id);
     },
-    [isDemoMode, setDeposits],
+    [updateDeposits, highlight],
   );
 
   const handleRollOver = useCallback(
     (oldId: string, newDeposit: TimeDeposit) => {
-      if (isDemoMode) {
-        setLiveDemoDeposits((prev) => [
-          ...prev.map((d) => (d.id === oldId ? { ...d, status: "settled" as const } : d)),
-          newDeposit,
-        ]);
-      } else {
-        setDeposits([
-          ...storedDeposits.map((d) => (d.id === oldId ? { ...d, status: "settled" as const } : d)),
-          newDeposit,
-        ]);
-      }
-      setHighlightedId(newDeposit.id);
-      setTimeout(() => setHighlightedId(null), 2500);
+      updateDeposits((prev) => [
+        ...prev.map((d) => (d.id === oldId ? { ...d, status: "settled" as const } : d)),
+        newDeposit,
+      ]);
+      highlight(newDeposit.id);
     },
-    [isDemoMode, storedDeposits, setDeposits],
+    [updateDeposits, highlight],
   );
 
   const handleDelete = useCallback(
     (id: string) => {
-      if (isDemoMode) {
-        setLiveDemoDeposits((prev) => prev.filter((d) => d.id !== id));
-      } else {
-        setDeposits(storedDeposits.filter((d) => d.id !== id));
-      }
+      updateDeposits((prev) => prev.filter((d) => d.id !== id));
     },
-    [isDemoMode, storedDeposits, setDeposits],
+    [updateDeposits],
   );
 
   const handleEdit = useCallback(

--- a/src/features/portfolio/hooks/__tests__/usePortfolioData.test.ts
+++ b/src/features/portfolio/hooks/__tests__/usePortfolioData.test.ts
@@ -46,7 +46,7 @@ describe("usePortfolioData — empty deposits", () => {
     expect(result.current.nextMaturity).toBeNull();
     expect(result.current.monthlyAllowance).toEqual([]);
     expect(result.current.currentMonthFull).toBeNull();
-    expect(result.current.currentMonthBreakdown).toEqual({ net: 0, pendingNet: 0, settledNet: 0 });
+    expect(result.current.currentMonthBreakdown).toEqual({ net: 0, pendingNet: 0, settledNet: 0, closedNet: 0 });
   });
 });
 

--- a/src/features/portfolio/hooks/usePortfolioData.ts
+++ b/src/features/portfolio/hooks/usePortfolioData.ts
@@ -44,7 +44,9 @@ function deriveEffectiveStatus(
   maturityDate: string | null,
   today: Date,
 ): TimeDeposit["status"] {
+  // Terminal states that require no auto-transition.
   if (deposit.status === "settled") return "settled";
+  if (deposit.status === "closed") return "closed";
   if (deposit.status === "active" && maturityDate !== null) {
     // parseLocalDate parses as local midnight (not UTC midnight) so the
     // comparison fires at midnight on the due date, not 8 hours later (UTC+8).
@@ -90,7 +92,7 @@ export function usePortfolioData(
 
   const totalPrincipal = useMemo(() => {
     return summaries
-      .filter((s) => s.effectiveStatus !== "settled")
+      .filter((s) => s.effectiveStatus !== "settled" && s.effectiveStatus !== "closed")
       .reduce((sum, s) => sum + s.deposit.principal, 0);
   }, [summaries]);
 
@@ -140,8 +142,10 @@ export function usePortfolioData(
   }, [summaries, today]);
 
   const monthlyAllowance = useMemo(() => {
-    // Projection excludes settled — their cash has already been received.
-    const projectionSummaries = summaries.filter((s) => s.effectiveStatus !== "settled");
+    // Projection excludes settled and closed — their cash has already been received.
+    const projectionSummaries = summaries.filter(
+      (s) => s.effectiveStatus !== "settled" && s.effectiveStatus !== "closed",
+    );
     return buildMonthlyAllowance(projectionSummaries);
   }, [summaries]);
 

--- a/src/features/portfolio/hooks/usePortfolioData.ts
+++ b/src/features/portfolio/hooks/usePortfolioData.ts
@@ -1,15 +1,18 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { buildDepositSummary } from "@/lib/domain/interest";
-import { buildMonthlyAllowance } from "@/lib/domain/cashflow";
+import { buildCashFlowProjection, buildCashFlowLedger } from "@/lib/domain/cashflow";
 import { monthKey, parseLocalDate } from "@/lib/domain/date";
-import type { Bank, DepositSummary, TimeDeposit } from "@/types";
+import type { Bank, DepositSummary, MonthlyAllowance, TimeDeposit } from "@/types";
+
+/** Runtime-derived display status. Never persisted to storage. */
+export type EffectiveStatus = TimeDeposit["status"];
 
 export type EnrichedSummary = DepositSummary & {
   // Derived-only status for UI display. Never written back to storage.
-  // active → matured when today >= maturityDate; settled is always settled.
-  effectiveStatus: TimeDeposit["status"];
+  // active → matured when today >= maturityDate; settled/closed are terminal.
+  effectiveStatus: EffectiveStatus;
 };
 
 export type NextMaturity = {
@@ -26,6 +29,8 @@ export type CurrentMonthBreakdown = {
   pendingNet: number;
   // Net amount from settled deposits with a payout this month.
   settledNet: number;
+  // Net amount from deposits closed early this month (principal + accrued returned).
+  closedNet: number;
 };
 
 export type PortfolioData = {
@@ -33,17 +38,17 @@ export type PortfolioData = {
   totalPrincipal: number;
   currentMonthBreakdown: CurrentMonthBreakdown;
   nextMaturity: NextMaturity | null;
-  // Projection: excludes settled deposits. Used for 12-month cash flow view.
-  monthlyAllowance: ReturnType<typeof buildMonthlyAllowance>;
-  // Full current-month picture: includes active + matured + settled entries.
-  currentMonthFull: ReturnType<typeof buildMonthlyAllowance>[number] | null;
+  // Forward projection: excludes settled/closed deposits. Used for 12-month cash flow view.
+  monthlyAllowance: MonthlyAllowance[];
+  // Full current-month ledger: includes active + matured + settled + closed entries.
+  currentMonthFull: MonthlyAllowance | null;
 };
 
 function deriveEffectiveStatus(
   deposit: TimeDeposit,
   maturityDate: string | null,
   today: Date,
-): TimeDeposit["status"] {
+): EffectiveStatus {
   // Terminal states that require no auto-transition.
   if (deposit.status === "settled") return "settled";
   if (deposit.status === "closed") return "closed";
@@ -60,12 +65,21 @@ export function usePortfolioData(
   deposits: TimeDeposit[],
   banks: Bank[],
 ): PortfolioData {
+  // Re-tick once per minute so maturity transitions fire correctly when the
+  // app is left open overnight. Without this, today is stale until remount.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   // Single "today" snapshot shared across all memos for a consistent render cycle.
   const today = useMemo(() => {
     const d = new Date();
     d.setHours(0, 0, 0, 0);
     return d;
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick]);
 
   const bankMap = useMemo(() => {
     const m = new Map<string, Bank>();
@@ -96,13 +110,12 @@ export function usePortfolioData(
       .reduce((sum, s) => sum + s.deposit.principal, 0);
   }, [summaries]);
 
-  // Current month: use ALL summaries (including settled) so the Income This Month
-  // card reflects the full picture — settled payouts are confirmed income.
-  // Also derives currentMonthFull here to avoid a second buildMonthlyAllowance(summaries) call.
+  // Ledger: use ALL summaries so the Income This Month card reflects the full
+  // picture — settled payouts are confirmed income, closed entries show early exits.
   const { currentMonthBreakdown, currentMonthFull } = useMemo(() => {
     const todayKey = monthKey(today);
-    const allAllowance = buildMonthlyAllowance(summaries);
-    const thisMonth = allAllowance.find((m) => m.monthKey === todayKey) ?? null;
+    const ledger = buildCashFlowLedger(summaries, today);
+    const thisMonth = ledger.find((m) => m.monthKey === todayKey) ?? null;
 
     const breakdown: CurrentMonthBreakdown = thisMonth
       ? {
@@ -113,8 +126,11 @@ export function usePortfolioData(
           settledNet: thisMonth.entries
             .filter((e) => e.status === "settled")
             .reduce((sum, e) => sum + e.amountNet, 0),
+          closedNet: thisMonth.entries
+            .filter((e) => e.status === "closed")
+            .reduce((sum, e) => sum + e.amountNet, 0),
         }
-      : { net: 0, pendingNet: 0, settledNet: 0 };
+      : { net: 0, pendingNet: 0, settledNet: 0, closedNet: 0 };
 
     return { currentMonthBreakdown: breakdown, currentMonthFull: thisMonth };
   }, [summaries, today]);
@@ -146,8 +162,8 @@ export function usePortfolioData(
     const projectionSummaries = summaries.filter(
       (s) => s.effectiveStatus !== "settled" && s.effectiveStatus !== "closed",
     );
-    return buildMonthlyAllowance(projectionSummaries);
-  }, [summaries]);
+    return buildCashFlowProjection(projectionSummaries, today);
+  }, [summaries, today]);
 
   return { summaries, totalPrincipal, currentMonthBreakdown, nextMaturity, monthlyAllowance, currentMonthFull };
 }

--- a/src/lib/data/demo.ts
+++ b/src/lib/data/demo.ts
@@ -192,6 +192,30 @@ export const deposits: TimeDeposit[] = [
   },
 
   // ─────────────────────────────────────────────
+  // CLOSED SAVINGS ACCOUNT
+  // Logic: Open-ended savings account closed ~2 months ago.
+  // Tests: "Closed" badge, historical cash flow entry, excluded from projections.
+  // ─────────────────────────────────────────────
+  {
+    id: "td-closed-apex-001",
+    bankId: "apex",
+    name: "Apex Savings Account",
+    principal: 200000,
+    startDate: monthsAgo(8),
+    termMonths: 12,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    taxRateOverride: 0.2,
+    flatRate: 0.04,
+    tiers: [{ upTo: null, rate: 0.04 }],
+    payoutFrequency: "monthly",
+    isOpenEnded: true,
+    status: "closed",
+    closeDate: monthsAgo(2),
+  },
+
+  // ─────────────────────────────────────────────
   // SHORT-TERM REINVESTMENT
   // ─────────────────────────────────────────────
   {

--- a/src/lib/domain/__tests__/accrued-interest.test.ts
+++ b/src/lib/domain/__tests__/accrued-interest.test.ts
@@ -26,13 +26,22 @@ function makeDeposit(overrides: Partial<TimeDeposit> = {}): TimeDeposit {
 }
 
 describe("calculateAccruedToDate", () => {
-  it("returns zero (or near-zero) interest when closed on startDate", () => {
+  it("returns 1-day minimum interest when closed on startDate", () => {
     const deposit = makeDeposit({ startDate: "2026-01-01" });
     const result = calculateAccruedToDate(deposit, bank, "2026-01-01");
-    // 0 days → engine clamps to 1 day minimum, but the amount is negligible
-    expect(result.netInterest).toBeGreaterThanOrEqual(0);
-    // At most 1 day of interest on ₱100k at 6% (≈ ₱13.15 net)
-    expect(result.netInterest).toBeLessThan(20);
+    // daysHeld = Math.max(0, 0) = 0 → yield engine clamps to 1-day minimum
+    // 1 day: 100000 * 0.06 * (1/365) * 0.8 ≈ 13.15
+    const expectedNet = 100_000 * 0.06 * (1 / 365) * 0.8;
+    expect(result.netInterest).toBeCloseTo(expectedNet, 2);
+    expect(result.grossInterest).toBeCloseTo(expectedNet / 0.8, 2);
+  });
+
+  it("uses 1-day minimum when closeDate is before startDate", () => {
+    const deposit = makeDeposit({ startDate: "2026-03-01" });
+    const result = calculateAccruedToDate(deposit, bank, "2026-02-01");
+    // Math.max(0, negative) → 0 → yield engine clamps to 1-day minimum
+    const expectedNet = 100_000 * 0.06 * (1 / 365) * 0.8;
+    expect(result.netInterest).toBeCloseTo(expectedNet, 2);
   });
 
   it("pro-rates interest for 30 days out of a 90-day deposit", () => {
@@ -63,6 +72,18 @@ describe("calculateAccruedToDate", () => {
     const result = calculateAccruedToDate(deposit, bank, "2026-03-02"); // 60 days
     const gross = 100_000 * 0.06 * (60 / 365);
     expect(result.netInterest).toBeCloseTo(gross * 0.8, 0);
+  });
+
+  it("computes interest for a tiered-rate deposit using the applicable tier", () => {
+    // Single tier covering all balances at 5% — same math as flat but exercising the tiered path
+    const deposit = makeDeposit({
+      startDate: "2026-01-01",
+      interestMode: "tiered",
+      tiers: [{ upTo: null, rate: 0.05 }],
+    });
+    const result = calculateAccruedToDate(deposit, bank, "2026-01-31"); // 30 days
+    const expected = 100_000 * 0.05 * (30 / 365) * 0.8;
+    expect(result.netInterest).toBeCloseTo(expected, 0);
   });
 
   it("handles open-ended savings closed after N days", () => {

--- a/src/lib/domain/__tests__/accrued-interest.test.ts
+++ b/src/lib/domain/__tests__/accrued-interest.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { calculateAccruedToDate } from "@/lib/domain/accrued-interest";
+import type { Bank, TimeDeposit } from "@/types";
+
+const bank: Bank = { id: "bank-1", name: "Test Bank", taxRate: 0.2 };
+
+function makeDeposit(overrides: Partial<TimeDeposit> = {}): TimeDeposit {
+  return {
+    id: "dep-1",
+    bankId: "bank-1",
+    name: "Test Deposit",
+    principal: 100_000,
+    startDate: "2026-01-01",
+    termMonths: 12,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    flatRate: 0.06,
+    tiers: [{ upTo: null, rate: 0.06 }],
+    payoutFrequency: "maturity",
+    dayCountConvention: 365,
+    isOpenEnded: false,
+    status: "active",
+    ...overrides,
+  };
+}
+
+describe("calculateAccruedToDate", () => {
+  it("returns zero (or near-zero) interest when closed on startDate", () => {
+    const deposit = makeDeposit({ startDate: "2026-01-01" });
+    const result = calculateAccruedToDate(deposit, bank, "2026-01-01");
+    // 0 days → engine clamps to 1 day minimum, but the amount is negligible
+    expect(result.netInterest).toBeGreaterThanOrEqual(0);
+    // At most 1 day of interest on ₱100k at 6% (≈ ₱13.15 net)
+    expect(result.netInterest).toBeLessThan(20);
+  });
+
+  it("pro-rates interest for 30 days out of a 90-day deposit", () => {
+    // 90-day TD: expected net interest for full term = 100000 * 0.06 * (90/365) * 0.8 ≈ 1183.56
+    // 30-day close: 100000 * 0.06 * (30/365) * 0.8 ≈ 394.52
+    const deposit = makeDeposit({ startDate: "2026-01-01", termMonths: 3 });
+    const result = calculateAccruedToDate(deposit, bank, "2026-01-31"); // 30 days
+    expect(result.netInterest).toBeCloseTo(100_000 * 0.06 * (30 / 365) * 0.8, 0);
+  });
+
+  it("uses the deposit's own dayCountConvention (360)", () => {
+    const deposit = makeDeposit({ startDate: "2026-01-01", dayCountConvention: 360 });
+    const result360 = calculateAccruedToDate(deposit, bank, "2026-01-31"); // 30 days
+    const expected = 100_000 * 0.06 * (30 / 360) * 0.8;
+    expect(result360.netInterest).toBeCloseTo(expected, 0);
+  });
+
+  it("applies taxRateOverride when present", () => {
+    // Bank taxRate=0.2, deposit override=0.1 → taxRate=0.1
+    const deposit = makeDeposit({ startDate: "2026-01-01", taxRateOverride: 0.1 });
+    const result = calculateAccruedToDate(deposit, bank, "2026-03-02"); // 60 days
+    const gross = 100_000 * 0.06 * (60 / 365);
+    expect(result.netInterest).toBeCloseTo(gross * 0.9, 0);
+  });
+
+  it("falls back to bank.taxRate when no override", () => {
+    const deposit = makeDeposit({ startDate: "2026-01-01" }); // no taxRateOverride
+    const result = calculateAccruedToDate(deposit, bank, "2026-03-02"); // 60 days
+    const gross = 100_000 * 0.06 * (60 / 365);
+    expect(result.netInterest).toBeCloseTo(gross * 0.8, 0);
+  });
+
+  it("handles open-ended savings closed after N days", () => {
+    const deposit = makeDeposit({
+      startDate: "2026-01-01",
+      isOpenEnded: true,
+      interestTreatment: "payout",
+      compounding: "daily",
+      flatRate: 0.04,
+    });
+    const result = calculateAccruedToDate(deposit, bank, "2026-04-11"); // 100 days
+    // Simple rate for clarity: 100000 * 0.04 * (100/365) * 0.8
+    expect(result.netInterest).toBeCloseTo(100_000 * 0.04 * (100 / 365) * 0.8, 0);
+  });
+});

--- a/src/lib/domain/__tests__/cashflow.test.ts
+++ b/src/lib/domain/__tests__/cashflow.test.ts
@@ -26,14 +26,22 @@ function makeDeposit(overrides: Partial<TimeDeposit> = {}): TimeDeposit {
 }
 
 // maturityDate is string | null: null for open-ended deposits.
-function makeSummary(deposit: TimeDeposit, maturityDate: string | null, netInterest: number): DepositSummary {
+// grossInterest must be passed explicitly — do not derive it with an implicit tax rate,
+// since buildMonthlyAllowance never reads grossInterest and the formula would silently
+// produce wrong values if a test uses a different tax rate.
+function makeSummary(
+  deposit: TimeDeposit,
+  maturityDate: string | null,
+  netInterest: number,
+  grossInterest = netInterest / 0.8,
+): DepositSummary {
   return {
     deposit,
     bank,
     maturityDate,
-    grossInterest: netInterest / 0.8,
+    grossInterest,
     netInterest,
-    grossTotal: deposit.principal + netInterest / 0.8,
+    grossTotal: deposit.principal + grossInterest,
     netTotal: deposit.principal + netInterest,
   };
 }
@@ -124,13 +132,40 @@ describe("buildMonthlyAllowance — empty input", () => {
   });
 });
 
+// ─── Settled deposit passthrough ─────────────────────────────────────────────
+//
+// usePortfolioData passes all statuses (including "settled") to buildMonthlyAllowance
+// for the currentMonthFull ledger. Settled deposits fall through to the normal
+// payout-date logic and must appear in the result with status "settled".
+
+describe("buildMonthlyAllowance — settled deposit", () => {
+  it("emits an entry in the maturity month with status 'settled'", () => {
+    const deposit = makeDeposit({
+      startDate: "2026-01-01",
+      termMonths: 3,
+      payoutFrequency: "maturity",
+      status: "settled",
+    });
+    const summary = {
+      ...makeSummary(deposit, "2026-04-01", 1800),
+      effectiveStatus: "settled" as const,
+    };
+
+    const result = buildMonthlyAllowance([summary]);
+    expect(result).toHaveLength(1);
+    expect(result[0].monthKey).toBe("2026-04");
+    expect(result[0].entries[0].status).toBe("settled");
+    expect(result[0].net).toBeCloseTo(1800, 6);
+  });
+});
+
 // ─── effectiveStatus override ─────────────────────────────────────────────────
 //
 // A deposit that matures today still has deposit.status === "active" in storage
 // (status is only written on explicit user action). usePortfolioData computes
 // effectiveStatus === "matured" at runtime and passes EnrichedSummary objects
 // to buildMonthlyAllowance. The function must prefer effectiveStatus so the KPI
-// "pending" pill and the Cash Flow "Due now" badge fire correctly on the due date.
+// "pending" pill and the Cash Flow "Matured" badge fire correctly on the due date.
 
 describe("buildMonthlyAllowance — effectiveStatus override", () => {
   it("uses effectiveStatus over deposit.status when provided", () => {

--- a/src/lib/domain/__tests__/cashflow.test.ts
+++ b/src/lib/domain/__tests__/cashflow.test.ts
@@ -154,6 +154,121 @@ describe("buildMonthlyAllowance — effectiveStatus override", () => {
   });
 });
 
+// ─── Closed deposits ──────────────────────────────────────────────────────────
+//
+// A closed deposit should emit a single historical entry in the closeDate month
+// (showing accrued net interest + full principal returned) and nothing else.
+
+describe("buildMonthlyAllowance — closed deposit", () => {
+  it("emits exactly one entry in the closeDate month", () => {
+    const deposit = makeDeposit({
+      startDate: "2026-01-01",
+      termMonths: 12,
+      status: "closed",
+      closeDate: "2026-03-15",
+      payoutFrequency: "maturity",
+    });
+    const summary = {
+      ...makeSummary(deposit, "2026-03-15", 500),
+      effectiveStatus: "closed" as const,
+    };
+
+    const result = buildMonthlyAllowance([summary]);
+    expect(result).toHaveLength(1);
+    expect(result[0].monthKey).toBe("2026-03");
+  });
+
+  it("uses accrued netInterest (not full-term) for the entry amount", () => {
+    const deposit = makeDeposit({
+      startDate: "2026-01-01",
+      termMonths: 12,
+      status: "closed",
+      closeDate: "2026-03-15",
+      payoutFrequency: "maturity",
+    });
+    // Caller passes the already-pro-rated netInterest from buildDepositSummary
+    const summary = {
+      ...makeSummary(deposit, "2026-03-15", 400),
+      effectiveStatus: "closed" as const,
+    };
+
+    const result = buildMonthlyAllowance([summary]);
+    expect(result[0].net).toBeCloseTo(400, 6);
+    expect(result[0].entries[0].amountNet).toBeCloseTo(400, 6);
+  });
+
+  it("includes principalReturned equal to full principal", () => {
+    const deposit = makeDeposit({
+      id: "dep-closed",
+      principal: 120_000,
+      startDate: "2026-01-01",
+      termMonths: 12,
+      status: "closed",
+      closeDate: "2026-03-15",
+      payoutFrequency: "maturity",
+    });
+    const summary = {
+      ...makeSummary(deposit, "2026-03-15", 400),
+      effectiveStatus: "closed" as const,
+    };
+
+    const result = buildMonthlyAllowance([summary]);
+    expect(result[0].entries[0].principalReturned).toBe(120_000);
+  });
+
+  it("marks the entry status as 'closed'", () => {
+    const deposit = makeDeposit({
+      startDate: "2026-01-01",
+      termMonths: 12,
+      status: "closed",
+      closeDate: "2026-03-15",
+      payoutFrequency: "maturity",
+    });
+    const summary = {
+      ...makeSummary(deposit, "2026-03-15", 400),
+      effectiveStatus: "closed" as const,
+    };
+
+    const result = buildMonthlyAllowance([summary]);
+    expect(result[0].entries[0].status).toBe("closed");
+  });
+
+  it("emits no entries when closeDate is absent", () => {
+    const deposit = makeDeposit({
+      startDate: "2026-01-01",
+      termMonths: 12,
+      status: "closed",
+      // no closeDate
+    });
+    const summary = {
+      ...makeSummary(deposit, null, 400),
+      effectiveStatus: "closed" as const,
+    };
+
+    const result = buildMonthlyAllowance([summary]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("does not generate future payout rows for a closed open-ended deposit", () => {
+    const deposit = makeDeposit({
+      startDate: "2025-06-01",
+      isOpenEnded: true,
+      payoutFrequency: "monthly",
+      status: "closed",
+      closeDate: "2026-02-10",
+    });
+    const summary = {
+      ...makeSummary(deposit, "2026-02-10", 300),
+      effectiveStatus: "closed" as const,
+    };
+
+    const result = buildMonthlyAllowance([summary]);
+    // Only 1 month (Feb 2026), not 12 future monthly rows
+    expect(result).toHaveLength(1);
+    expect(result[0].monthKey).toBe("2026-02");
+  });
+});
+
 // ─── Open-ended (savings) projection ─────────────────────────────────────────
 //
 // Open-ended deposits project 12 monthly payouts anchored to startDate.

--- a/src/lib/domain/accrued-interest.ts
+++ b/src/lib/domain/accrued-interest.ts
@@ -1,0 +1,37 @@
+import { calculateNetYield } from "@/lib/domain/yield-engine";
+import { differenceInCalendarDays, parseLocalDate } from "@/lib/domain/date";
+import type { Bank, TimeDeposit } from "@/types";
+import type { YieldResult } from "@/lib/domain/yield-engine";
+
+/**
+ * Calculate pro-rated interest from a deposit's startDate up to a given closeDate.
+ * Uses the deposit's own dayCountConvention (360 or 365, defaulting to 365).
+ * Delegates to the existing yield engine — no duplicated math.
+ */
+export function calculateAccruedToDate(
+  deposit: TimeDeposit,
+  bank: Bank,
+  closeDate: string,
+): YieldResult {
+  const daysHeld = Math.max(
+    0,
+    differenceInCalendarDays(
+      parseLocalDate(closeDate),
+      parseLocalDate(deposit.startDate),
+    ),
+  );
+
+  return calculateNetYield({
+    principal: deposit.principal,
+    startDate: deposit.startDate,
+    termMonths: 0,
+    termDays: daysHeld,
+    flatRate: deposit.flatRate,
+    tiers: deposit.tiers,
+    interestMode: deposit.interestMode,
+    interestTreatment: deposit.interestTreatment,
+    compounding: deposit.compounding,
+    taxRate: deposit.taxRateOverride ?? bank.taxRate,
+    dayCountConvention: deposit.dayCountConvention ?? 365,
+  });
+}

--- a/src/lib/domain/cashflow.ts
+++ b/src/lib/domain/cashflow.ts
@@ -19,6 +19,30 @@ export function buildMonthlyAllowance(summaries: SummaryInput[]) {
   for (const summary of summaries) {
     const { deposit, netInterest } = summary;
 
+    // Closed deposits: emit a single historical entry for the closeDate month.
+    // netInterest here is already pro-rated (buildDepositSummary handles it).
+    // Skip all regular payout-date generation.
+    if ((summary.effectiveStatus ?? deposit.status) === "closed") {
+      const closeDate = deposit.closeDate;
+      if (!closeDate) continue;
+      const payoutDate = parseLocalDate(closeDate);
+      const key = monthKey(payoutDate);
+      const label = formatMonthLabel(payoutDate);
+      const current = map.get(key) ?? { monthKey: key, label, net: 0, entries: [] };
+      current.net += netInterest;
+      current.entries.push({
+        depositId: deposit.id,
+        name: deposit.name,
+        bankName: summary.bank.name,
+        payoutFrequency: "maturity",
+        amountNet: netInterest,
+        principalReturned: deposit.principal,
+        status: "closed",
+      });
+      map.set(key, current);
+      continue;
+    }
+
     // parseLocalDate ensures payout dates fall on the correct local calendar day.
     // new Date(deposit.startDate) would parse as UTC midnight, which shifts the
     // day by 1 in UTC+ timezones (e.g. March 15 at midnight UTC = March 15 at

--- a/src/lib/domain/cashflow.ts
+++ b/src/lib/domain/cashflow.ts
@@ -1,5 +1,14 @@
-// Precondition: summaries must NOT include settled deposits.
-// Filter them out in the caller (e.g. usePortfolioData) before passing here.
+/**
+ * buildCashFlowProjection — forward-looking only.
+ *   Pass active + matured summaries. Settled and closed deposits are excluded
+ *   by the caller because their cash has already been received.
+ *   Used for the 12-month chart in the Cash Flow page.
+ *
+ * buildCashFlowLedger — full historical + current picture.
+ *   Pass all summaries. Settled entries land in their maturity month;
+ *   closed entries land in their closeDate month.
+ *   Used to derive currentMonthFull and currentMonthBreakdown in the KPI cards.
+ */
 import type { MonthlyAllowance, DepositSummary, TimeDeposit } from "@/types";
 import { addMonths, formatMonthLabel, monthKey, parseLocalDate } from "@/lib/domain/date";
 
@@ -8,21 +17,21 @@ const OPEN_ENDED_PROJECTION_MONTHS = 12;
 
 // Accepts plain DepositSummary or EnrichedSummary (which carries effectiveStatus).
 // effectiveStatus is the runtime-derived status (e.g. "active" → "matured" on due date)
-// and takes precedence over the stored deposit.status so that "Due now" badges and
+// and takes precedence over the stored deposit.status so that "Matured" badges and
 // the "pending" pill in KPI cards reflect the actual state without requiring a storage write.
 type SummaryInput = DepositSummary & { effectiveStatus?: TimeDeposit["status"] };
 
-export function buildMonthlyAllowance(summaries: SummaryInput[]) {
+function buildAllowanceMap(summaries: SummaryInput[], today: Date): Map<string, MonthlyAllowance> {
   const map = new Map<string, MonthlyAllowance>();
-  const today = new Date();
 
   for (const summary of summaries) {
     const { deposit, netInterest } = summary;
+    const effectiveStatus = summary.effectiveStatus ?? deposit.status;
 
     // Closed deposits: emit a single historical entry for the closeDate month.
     // netInterest here is already pro-rated (buildDepositSummary handles it).
     // Skip all regular payout-date generation.
-    if ((summary.effectiveStatus ?? deposit.status) === "closed") {
+    if (effectiveStatus === "closed") {
       const closeDate = deposit.closeDate;
       if (!closeDate) continue;
       const payoutDate = parseLocalDate(closeDate);
@@ -76,11 +85,11 @@ export function buildMonthlyAllowance(summaries: SummaryInput[]) {
       payoutDates =
         deposit.payoutFrequency === "monthly"
           ? [
-              ...Array.from({ length: Math.floor(termMonths) }, (_, i) =>
-                addMonths(start, i + 1),
-              ),
-              ...(isWholeMonthTerm ? [] : [addMonths(start, termMonths)]),
-            ]
+            ...Array.from({ length: Math.floor(termMonths) }, (_, i) =>
+              addMonths(start, i + 1),
+            ),
+            ...(isWholeMonthTerm ? [] : [addMonths(start, termMonths)]),
+          ]
           : [parseLocalDate(summary.maturityDate!)];
     }
 
@@ -112,12 +121,50 @@ export function buildMonthlyAllowance(summaries: SummaryInput[]) {
             : 0,
         // Prefer effectiveStatus (runtime-derived) over stored deposit.status so
         // a deposit whose stored status is "active" but that matures today is
-        // correctly surfaced as "matured" in the KPI pending pill and "Due now" badge.
-        status: summary.effectiveStatus ?? deposit.status,
+        // correctly surfaced as "matured" in the KPI pending pill and "Matured" badge.
+        status: effectiveStatus,
       });
       map.set(key, current);
     }
   }
 
+  return map;
+}
+
+function sortedFromMap(map: Map<string, MonthlyAllowance>): MonthlyAllowance[] {
   return Array.from(map.values()).sort((a, b) => a.monthKey.localeCompare(b.monthKey));
+}
+
+/**
+ * Forward-looking 12-month projection.
+ * Caller must exclude settled and closed summaries before passing here.
+ */
+export function buildCashFlowProjection(
+  summaries: SummaryInput[],
+  today = new Date(),
+): MonthlyAllowance[] {
+  return sortedFromMap(buildAllowanceMap(summaries, today));
+}
+
+/**
+ * Full historical + current-month ledger.
+ * Accepts all statuses. Settled entries land in their maturity month;
+ * closed entries land in their closeDate month.
+ */
+export function buildCashFlowLedger(
+  summaries: SummaryInput[],
+  today = new Date(),
+): MonthlyAllowance[] {
+  return sortedFromMap(buildAllowanceMap(summaries, today));
+}
+
+/**
+ * @deprecated Use buildCashFlowProjection or buildCashFlowLedger.
+ * Kept temporarily so external callers (tests, ai-context) can migrate incrementally.
+ */
+export function buildMonthlyAllowance(
+  summaries: SummaryInput[],
+  today = new Date(),
+): MonthlyAllowance[] {
+  return sortedFromMap(buildAllowanceMap(summaries, today));
 }

--- a/src/lib/domain/interest.ts
+++ b/src/lib/domain/interest.ts
@@ -1,10 +1,45 @@
 import type { Bank, DepositSummary, TimeDeposit } from "@/types";
 import { calculateNetYield } from "@/lib/domain/yield-engine";
+import { differenceInCalendarDays, parseLocalDate } from "@/lib/domain/date";
 
 // Projection window for open-ended deposits (rolling 12 months).
 const OPEN_ENDED_PROJECTION_MONTHS = 12;
 
 export function buildDepositSummary(deposit: TimeDeposit, bank: Bank): DepositSummary {
+  // Closed deposits: compute interest accrued up to closeDate (pro-rated).
+  // This covers both time deposits closed early and open-ended accounts closed.
+  if (deposit.status === "closed" && deposit.closeDate) {
+    const daysHeld = Math.max(
+      0,
+      differenceInCalendarDays(
+        parseLocalDate(deposit.closeDate),
+        parseLocalDate(deposit.startDate),
+      ),
+    );
+    const result = calculateNetYield({
+      principal: deposit.principal,
+      startDate: deposit.startDate,
+      termMonths: 0,
+      termDays: daysHeld,
+      flatRate: deposit.flatRate,
+      tiers: deposit.tiers,
+      interestMode: deposit.interestMode,
+      interestTreatment: deposit.interestTreatment,
+      compounding: deposit.compounding,
+      taxRate: deposit.taxRateOverride ?? bank.taxRate,
+      dayCountConvention: deposit.dayCountConvention ?? 365,
+    });
+    return {
+      deposit,
+      bank,
+      maturityDate: deposit.closeDate,
+      grossInterest: result.grossInterest,
+      netInterest: result.netInterest,
+      grossTotal: deposit.principal + result.grossInterest,
+      netTotal: deposit.principal + result.netInterest,
+    };
+  }
+
   if (deposit.isOpenEnded) {
     // Open-ended deposits have no fixed maturity. Project interest over a
     // rolling 12-month window for display purposes only.

--- a/src/lib/domain/interest.ts
+++ b/src/lib/domain/interest.ts
@@ -1,34 +1,14 @@
 import type { Bank, DepositSummary, TimeDeposit } from "@/types";
 import { calculateNetYield } from "@/lib/domain/yield-engine";
-import { differenceInCalendarDays, parseLocalDate } from "@/lib/domain/date";
+import { calculateAccruedToDate } from "@/lib/domain/accrued-interest";
 
 // Projection window for open-ended deposits (rolling 12 months).
 const OPEN_ENDED_PROJECTION_MONTHS = 12;
 
 export function buildDepositSummary(deposit: TimeDeposit, bank: Bank): DepositSummary {
-  // Closed deposits: compute interest accrued up to closeDate (pro-rated).
-  // This covers both time deposits closed early and open-ended accounts closed.
+  // Closed deposits: pro-rate interest up to closeDate.
   if (deposit.status === "closed" && deposit.closeDate) {
-    const daysHeld = Math.max(
-      0,
-      differenceInCalendarDays(
-        parseLocalDate(deposit.closeDate),
-        parseLocalDate(deposit.startDate),
-      ),
-    );
-    const result = calculateNetYield({
-      principal: deposit.principal,
-      startDate: deposit.startDate,
-      termMonths: 0,
-      termDays: daysHeld,
-      flatRate: deposit.flatRate,
-      tiers: deposit.tiers,
-      interestMode: deposit.interestMode,
-      interestTreatment: deposit.interestTreatment,
-      compounding: deposit.compounding,
-      taxRate: deposit.taxRateOverride ?? bank.taxRate,
-      dayCountConvention: deposit.dayCountConvention ?? 365,
-    });
+    const result = calculateAccruedToDate(deposit, bank, deposit.closeDate);
     return {
       deposit,
       bank,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,9 @@ export type TimeDeposit = {
   payoutFrequency: PayoutFrequency;
   dayCountConvention?: 360 | 365;
   isOpenEnded?: boolean;
-  status: "active" | "matured" | "settled";
+  status: "active" | "matured" | "settled" | "closed";
+  /** ISO date (YYYY-MM-DD) of early closure. Set when status transitions to "closed". */
+  closeDate?: string;
 };
 
 export type Bank = {
@@ -60,6 +62,6 @@ export type MonthlyAllowance = {
     payoutFrequency: PayoutFrequency;
     amountNet: number;
     principalReturned?: number;
-    status: "active" | "matured" | "settled";
+    status: "active" | "matured" | "settled" | "closed";
   }>;
 };

--- a/tests/a11y/basic.a11y.spec.ts
+++ b/tests/a11y/basic.a11y.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 import type { TimeDeposit } from "../../src/types";
+import { makeActiveTimeDeposit, makeClosedTimeDeposit } from "../fixtures/deposits";
 
 const seedDeposit: TimeDeposit = {
   id: "a11y-test-dep",
@@ -24,8 +25,10 @@ const seedDeposit: TimeDeposit = {
 test("dashboard page has no critical a11y issues", async ({ page }) => {
   await page.goto("/");
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
 test("dashboard page with data has no critical a11y issues", async ({ page }) => {
@@ -37,8 +40,10 @@ test("dashboard page with data has no critical a11y issues", async ({ page }) =>
   await expect(page.getByRole("heading", { level: 1, name: "Portfolio" })).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
 test("add investment dialog has no critical a11y issues", async ({ page }) => {
@@ -46,9 +51,13 @@ test("add investment dialog has no critical a11y issues", async ({ page }) => {
   await page.getByRole("button", { name: "Add my first investment" }).click();
   await expect(page.getByRole("dialog")).toBeVisible();
 
-  const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  // Scope to the dialog only — the background LandingAnimation is decorative
+  // (aria-hidden) and should not be checked for color contrast.
+  const results = await new AxeBuilder({ page }).include('[role="dialog"]').analyze();
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
 test("investment page has no critical a11y issues", async ({ page }) => {
@@ -61,8 +70,10 @@ test("investment page has no critical a11y issues", async ({ page }) => {
   await expect(page.getByText("Beacon Bank", { exact: true })).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
 test("edit investment dialog has no critical a11y issues", async ({ page }) => {
@@ -80,8 +91,10 @@ test("edit investment dialog has no critical a11y issues", async ({ page }) => {
   await expect(page.getByRole("dialog")).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
 test("cash flow page has no critical a11y issues", async ({ page }) => {
@@ -94,8 +107,10 @@ test("cash flow page has no critical a11y issues", async ({ page }) => {
   await expect(page.getByRole("heading", { level: 1, name: "Cash Flow" })).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
 test("cash flow page with data has no critical a11y issues", async ({ page }) => {
@@ -107,32 +122,17 @@ test("cash flow page with data has no critical a11y issues", async ({ page }) =>
   await expect(page.getByRole("heading", { level: 1, name: "Cash Flow" })).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
-test("close early dialog has no critical a11y issues", async ({ page }) => {
-  const activeDeposit: TimeDeposit = {
-    id: "a11y-close-td",
-    bankId: "Beacon Bank",
-    name: "Beacon 6M TD",
-    principal: 200000,
-    startDate: "2026-03-01",
-    termMonths: 6,
-    interestMode: "simple",
-    interestTreatment: "payout",
-    compounding: "daily",
-    taxRateOverride: 0.2,
-    flatRate: 0.06,
-    tiers: [{ upTo: null, rate: 0.06 }],
-    payoutFrequency: "maturity",
-    dayCountConvention: 365,
-    isOpenEnded: false,
-    status: "active",
-  };
+test("close early dialog has no critical/serious a11y issues", async ({ page }) => {
+  const activeDeposit = makeActiveTimeDeposit({ id: "a11y-close-td" });
 
   await page.clock.setFixedTime(new Date(2026, 2, 6));
-  await page.addInitScript((deposit) => {
+  await page.addInitScript((deposit: TimeDeposit) => {
     localStorage.setItem("yf:deposits", JSON.stringify([deposit]));
   }, activeDeposit);
 
@@ -144,42 +144,52 @@ test("close early dialog has no critical a11y issues", async ({ page }) => {
   await expect(page.getByRole("alertdialog")).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
-test("investments page with closed deposit has no critical a11y issues", async ({ page }) => {
-  const closedDeposit: TimeDeposit = {
-    id: "a11y-closed-dep",
-    bankId: "Beacon Bank",
-    name: "Beacon 3M (closed)",
-    principal: 150000,
-    startDate: "2025-09-01",
-    termMonths: 6,
-    interestMode: "simple",
-    interestTreatment: "payout",
-    compounding: "daily",
-    taxRateOverride: 0.2,
-    flatRate: 0.055,
-    tiers: [{ upTo: null, rate: 0.055 }],
-    payoutFrequency: "maturity",
-    dayCountConvention: 365,
-    isOpenEnded: false,
-    status: "closed",
-    closeDate: "2026-01-15",
-  };
+test("investments page with closed deposit has no critical/serious a11y issues", async ({ page }) => {
+  const closedDeposit = makeClosedTimeDeposit({ id: "a11y-closed-dep" });
 
-  await page.addInitScript((deposit) => {
+  await page.addInitScript((deposit: TimeDeposit) => {
     localStorage.setItem("yf:deposits", JSON.stringify([deposit]));
   }, closedDeposit);
 
   await page.goto("/investments");
-  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await page.getByRole("switch", { name: "Show inactive" }).click();
   await expect(page.getByText("Beacon 3M (closed)")).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
+});
+
+test("reopen menu item on closed deposit has no critical/serious a11y issues", async ({ page }) => {
+  const closedDeposit = makeClosedTimeDeposit({ id: "a11y-reopen-dep" });
+
+  await page.addInitScript((deposit: TimeDeposit) => {
+    localStorage.setItem("yf:deposits", JSON.stringify([deposit]));
+  }, closedDeposit);
+
+  await page.goto("/investments");
+  await page.getByRole("switch", { name: "Show inactive" }).click();
+  await expect(page.getByText("Beacon 3M (closed)")).toBeVisible();
+
+  await page.getByRole("button", { name: /more options for beacon 3m \(closed\)/i }).click();
+  await expect(page.getByRole("menuitem", { name: /reopen/i })).toBeVisible();
+
+  // Scope to the open menu — the Base UI dropdown sets aria-hidden on the
+  // background (sidebar, toolbar) which causes aria-hidden-focus false positives
+  // for elements the user can't reach while the menu is open.
+  const results = await new AxeBuilder({ page }).include('[role="menu"]').analyze();
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });
 
 test("settings page has no critical a11y issues", async ({ page }) => {
@@ -191,6 +201,8 @@ test("settings page has no critical a11y issues", async ({ page }) => {
   await expect(page.getByRole("heading", { level: 1, name: "Settings" })).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(critical).toEqual([]);
+  const blocking = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blocking).toEqual([]);
 });

--- a/tests/a11y/basic.a11y.spec.ts
+++ b/tests/a11y/basic.a11y.spec.ts
@@ -111,6 +111,77 @@ test("cash flow page with data has no critical a11y issues", async ({ page }) =>
   expect(critical).toEqual([]);
 });
 
+test("close early dialog has no critical a11y issues", async ({ page }) => {
+  const activeDeposit: TimeDeposit = {
+    id: "a11y-close-td",
+    bankId: "Beacon Bank",
+    name: "Beacon 6M TD",
+    principal: 200000,
+    startDate: "2026-03-01",
+    termMonths: 6,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    taxRateOverride: 0.2,
+    flatRate: 0.06,
+    tiers: [{ upTo: null, rate: 0.06 }],
+    payoutFrequency: "maturity",
+    dayCountConvention: 365,
+    isOpenEnded: false,
+    status: "active",
+  };
+
+  await page.clock.setFixedTime(new Date(2026, 2, 6));
+  await page.addInitScript((deposit) => {
+    localStorage.setItem("yf:deposits", JSON.stringify([deposit]));
+  }, activeDeposit);
+
+  await page.goto("/investments");
+  await expect(page.getByText("Beacon 6M TD")).toBeVisible();
+
+  await page.getByRole("button", { name: /more options for beacon 6m td/i }).click();
+  await page.getByRole("menuitem", { name: /close early/i }).click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  const critical = results.violations.filter((v) => v.impact === "critical");
+  expect(critical).toEqual([]);
+});
+
+test("investments page with closed deposit has no critical a11y issues", async ({ page }) => {
+  const closedDeposit: TimeDeposit = {
+    id: "a11y-closed-dep",
+    bankId: "Beacon Bank",
+    name: "Beacon 3M (closed)",
+    principal: 150000,
+    startDate: "2025-09-01",
+    termMonths: 6,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    taxRateOverride: 0.2,
+    flatRate: 0.055,
+    tiers: [{ upTo: null, rate: 0.055 }],
+    payoutFrequency: "maturity",
+    dayCountConvention: 365,
+    isOpenEnded: false,
+    status: "closed",
+    closeDate: "2026-01-15",
+  };
+
+  await page.addInitScript((deposit) => {
+    localStorage.setItem("yf:deposits", JSON.stringify([deposit]));
+  }, closedDeposit);
+
+  await page.goto("/investments");
+  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await expect(page.getByText("Beacon 3M (closed)")).toBeVisible();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  const critical = results.violations.filter((v) => v.impact === "critical");
+  expect(critical).toEqual([]);
+});
+
 test("settings page has no critical a11y issues", async ({ page }) => {
   await page.addInitScript((deposit) => {
     localStorage.setItem("yf:deposits", JSON.stringify([deposit]));

--- a/tests/fixtures/deposits.ts
+++ b/tests/fixtures/deposits.ts
@@ -1,0 +1,48 @@
+import type { TimeDeposit } from "../../src/types";
+
+/** A 6-month active time deposit starting 2026-03-01. Used across close and a11y tests. */
+export function makeActiveTimeDeposit(overrides: Partial<TimeDeposit> = {}): TimeDeposit {
+  return {
+    id: "fixture-active-td",
+    bankId: "Beacon Bank",
+    name: "Beacon 6M TD",
+    principal: 200_000,
+    startDate: "2026-03-01",
+    termMonths: 6,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    taxRateOverride: 0.2,
+    flatRate: 0.06,
+    tiers: [{ upTo: null, rate: 0.06 }],
+    payoutFrequency: "maturity",
+    dayCountConvention: 365,
+    isOpenEnded: false,
+    status: "active",
+    ...overrides,
+  };
+}
+
+/** A closed time deposit with a closeDate in the past. Used in reopen and a11y tests. */
+export function makeClosedTimeDeposit(overrides: Partial<TimeDeposit> = {}): TimeDeposit {
+  return {
+    id: "fixture-closed-td",
+    bankId: "Beacon Bank",
+    name: "Beacon 3M (closed)",
+    principal: 150_000,
+    startDate: "2025-09-01",
+    termMonths: 6,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    taxRateOverride: 0.2,
+    flatRate: 0.055,
+    tiers: [{ upTo: null, rate: 0.055 }],
+    payoutFrequency: "maturity",
+    dayCountConvention: 365,
+    isOpenEnded: false,
+    status: "closed",
+    closeDate: "2026-01-15",
+    ...overrides,
+  };
+}

--- a/tests/flows/close-investment.spec.ts
+++ b/tests/flows/close-investment.spec.ts
@@ -75,7 +75,7 @@ async function seedAndGo(page: Page, deposits: TimeDeposit[]) {
   await page.goto("/investments");
 }
 
-// ─── Close Early (time deposit) ───────────────────────────────────────────────
+// ─── Close early (time deposit) ───────────────────────────────────────────────
 
 test("close early — dialog opens from action menu with maturity warning", async ({ page }) => {
   await seedAndGo(page, [tdActive]);
@@ -110,34 +110,37 @@ test("close early — confirm transitions deposit to Closed and hides it", async
   await page.getByRole("menuitem", { name: /close early/i }).click();
   await expect(page.getByRole("alertdialog")).toBeVisible();
 
-  await page.getByRole("button", { name: /close account/i }).last().click();
+  await page.getByRole("alertdialog").getByRole("button", { name: /close account/i }).click();
   await expect(page.getByRole("alertdialog")).not.toBeVisible();
 
   // Closed deposit is hidden by default — row should be gone
   await expect(page.getByText("Meridian 6M TD", { exact: true })).not.toBeVisible();
 });
 
-test("close early — closed deposit visible after toggling 'Show closed / settled'", async ({ page }) => {
+test("close early — closed deposit visible after toggling 'Show inactive'", async ({ page }) => {
   await seedAndGo(page, [tdActive]);
 
   await page.getByRole("button", { name: /more options for meridian 6m td/i }).click();
   await page.getByRole("menuitem", { name: /close early/i }).click();
-  await page.getByRole("button", { name: /close account/i }).last().click();
+  await page.getByRole("alertdialog").getByRole("button", { name: /close account/i }).click();
 
   // Toggle on
-  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await page.getByRole("switch", { name: "Show inactive" }).click();
 
   await expect(page.getByText("Meridian 6M TD", { exact: true })).toBeVisible();
-  await expect(page.getByText("Closed").first()).toBeVisible();
+  // Scope the Closed badge to the deposit's row
+  const depositRow = page.getByRole("row").filter({ hasText: "Meridian 6M TD" });
+  await expect(depositRow.getByText("Closed")).toBeVisible();
 });
 
-// ─── Close Account (open-ended savings) ───────────────────────────────────────
+// ─── Close account (open-ended savings) ───────────────────────────────────────
 
 test("close account (savings) — dialog has no maturity warning", async ({ page }) => {
   await seedAndGo(page, [savingsActive]);
 
   await page.getByRole("button", { name: /more options for apex savings account/i }).click();
-  await page.getByRole("menuitem", { name: /close account/i }).click();
+  // Open-ended deposits show "Withdraw & close" in the menu
+  await page.getByRole("menuitem", { name: /withdraw & close/i }).click();
 
   await expect(page.getByRole("alertdialog")).toBeVisible();
   await expect(page.getByText(/closing before maturity/i)).not.toBeVisible();
@@ -148,8 +151,8 @@ test("close account (savings) — confirm hides the savings deposit", async ({ p
   await seedAndGo(page, [savingsActive]);
 
   await page.getByRole("button", { name: /more options for apex savings account/i }).click();
-  await page.getByRole("menuitem", { name: /close account/i }).click();
-  await page.getByRole("button", { name: /close account/i }).last().click();
+  await page.getByRole("menuitem", { name: /withdraw & close/i }).click();
+  await page.getByRole("alertdialog").getByRole("button", { name: /close account/i }).click();
 
   await expect(page.getByText("Apex Savings Account", { exact: true })).not.toBeVisible();
 });
@@ -161,10 +164,11 @@ test("closed deposit hidden by default, shown after toggle", async ({ page }) =>
 
   await expect(page.getByText("Horizon 3M (closed)")).not.toBeVisible();
 
-  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await page.getByRole("switch", { name: "Show inactive" }).click();
 
   await expect(page.getByText("Horizon 3M (closed)")).toBeVisible();
-  await expect(page.getByText("Closed").first()).toBeVisible();
+  const closedRow = page.getByRole("row").filter({ hasText: "Horizon 3M (closed)" });
+  await expect(closedRow.getByText("Closed", { exact: true })).toBeVisible();
 });
 
 // ─── Reopen ───────────────────────────────────────────────────────────────────
@@ -173,14 +177,33 @@ test("reopen — closed deposit reverts to active after reopening", async ({ pag
   await seedAndGo(page, [tdClosed]);
 
   // Show closed deposits first
-  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await page.getByRole("switch", { name: "Show inactive" }).click();
   await expect(page.getByText("Horizon 3M (closed)")).toBeVisible();
 
   await page.getByRole("button", { name: /more options for horizon 3m \(closed\)/i }).click();
   await page.getByRole("menuitem", { name: /reopen/i }).click();
 
   // After reopening, toggle back off — deposit should be visible (active)
-  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await page.getByRole("switch", { name: "Show inactive" }).click();
   await expect(page.getByText("Horizon 3M (closed)")).toBeVisible();
-  await expect(page.getByText("Active").first()).toBeVisible();
+  const activeRow = page.getByRole("row").filter({ hasText: "Horizon 3M (closed)" });
+  await expect(activeRow.getByText("Active")).toBeVisible();
+});
+
+// ─── Undo close via toast ─────────────────────────────────────────────────────
+
+test("close early — undo via toast reverts deposit to active", async ({ page }) => {
+  await seedAndGo(page, [tdActive]);
+
+  await page.getByRole("button", { name: /more options for meridian 6m td/i }).click();
+  await page.getByRole("menuitem", { name: /close early/i }).click();
+  await page.getByRole("alertdialog").getByRole("button", { name: /close account/i }).click();
+
+  // Toast appears — click Undo
+  await page.getByRole("button", { name: /undo/i }).click();
+
+  // Deposit is active again — visible without the toggle
+  await expect(page.getByText("Meridian 6M TD", { exact: true })).toBeVisible();
+  const reopenedRow = page.getByRole("row").filter({ hasText: "Meridian 6M TD" });
+  await expect(reopenedRow.getByText("Active")).toBeVisible();
 });

--- a/tests/flows/close-investment.spec.ts
+++ b/tests/flows/close-investment.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect, type Page } from "@playwright/test";
+import type { TimeDeposit } from "../../src/types";
+
+// ─── Seed data ────────────────────────────────────────────────────────────────
+// Frozen "today": 2026-03-06.
+// td-active: matures 2026-09-01 (6 months away — clearly before maturity).
+// savings-active: open-ended, no maturity date.
+// td-closed: already closed, closeDate in the past.
+
+const tdActive: TimeDeposit = {
+  id: "close-td-active",
+  bankId: "Meridian Savings Bank",
+  name: "Meridian 6M TD",
+  principal: 200000,
+  startDate: "2026-03-01",
+  termMonths: 6,
+  interestMode: "simple",
+  interestTreatment: "payout",
+  compounding: "daily",
+  taxRateOverride: 0.2,
+  flatRate: 0.06,
+  tiers: [{ upTo: null, rate: 0.06 }],
+  payoutFrequency: "maturity",
+  dayCountConvention: 365,
+  isOpenEnded: false,
+  status: "active",
+};
+
+const savingsActive: TimeDeposit = {
+  id: "close-savings-active",
+  bankId: "Apex Rural Bank",
+  name: "Apex Savings Account",
+  principal: 100000,
+  startDate: "2025-09-01",
+  termMonths: 12,
+  interestMode: "simple",
+  interestTreatment: "payout",
+  compounding: "daily",
+  taxRateOverride: 0.2,
+  flatRate: 0.04,
+  tiers: [{ upTo: null, rate: 0.04 }],
+  payoutFrequency: "monthly",
+  dayCountConvention: 365,
+  isOpenEnded: true,
+  status: "active",
+};
+
+const tdClosed: TimeDeposit = {
+  id: "close-td-closed",
+  bankId: "Horizon Digital Bank",
+  name: "Horizon 3M (closed)",
+  principal: 150000,
+  startDate: "2025-10-01",
+  termMonths: 12,
+  interestMode: "simple",
+  interestTreatment: "payout",
+  compounding: "daily",
+  taxRateOverride: 0.2,
+  flatRate: 0.055,
+  tiers: [{ upTo: null, rate: 0.055 }],
+  payoutFrequency: "maturity",
+  dayCountConvention: 365,
+  isOpenEnded: false,
+  status: "closed",
+  closeDate: "2026-01-15",
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function seedAndGo(page: Page, deposits: TimeDeposit[]) {
+  await page.clock.setFixedTime(new Date(2026, 2, 6)); // Mar 6 2026
+  await page.addInitScript((deps) => {
+    localStorage.setItem("yf:deposits", JSON.stringify(deps));
+  }, deposits);
+  await page.goto("/investments");
+}
+
+// ─── Close Early (time deposit) ───────────────────────────────────────────────
+
+test("close early — dialog opens from action menu with maturity warning", async ({ page }) => {
+  await seedAndGo(page, [tdActive]);
+
+  await page.getByRole("button", { name: /more options for meridian 6m td/i }).click();
+  await page.getByRole("menuitem", { name: /close early/i }).click();
+
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+  await expect(page.getByText(/closing before maturity/i)).toBeVisible();
+  await expect(page.getByText(/close account/i).last()).toBeVisible();
+});
+
+test("close early — cancel dismisses dialog without changing status", async ({ page }) => {
+  await seedAndGo(page, [tdActive]);
+
+  await page.getByRole("button", { name: /more options for meridian 6m td/i }).click();
+  await page.getByRole("menuitem", { name: /close early/i }).click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+
+  await page.getByRole("button", { name: /cancel/i }).click();
+  await expect(page.getByRole("alertdialog")).not.toBeVisible();
+
+  // Deposit still active — no "Closed" badge
+  await expect(page.getByText("Active", { exact: true })).toBeVisible();
+  await expect(page.getByText("Closed", { exact: true })).not.toBeVisible();
+});
+
+test("close early — confirm transitions deposit to Closed and hides it", async ({ page }) => {
+  await seedAndGo(page, [tdActive]);
+
+  await page.getByRole("button", { name: /more options for meridian 6m td/i }).click();
+  await page.getByRole("menuitem", { name: /close early/i }).click();
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+
+  await page.getByRole("button", { name: /close account/i }).last().click();
+  await expect(page.getByRole("alertdialog")).not.toBeVisible();
+
+  // Closed deposit is hidden by default — row should be gone
+  await expect(page.getByText("Meridian 6M TD", { exact: true })).not.toBeVisible();
+});
+
+test("close early — closed deposit visible after toggling 'Show closed / settled'", async ({ page }) => {
+  await seedAndGo(page, [tdActive]);
+
+  await page.getByRole("button", { name: /more options for meridian 6m td/i }).click();
+  await page.getByRole("menuitem", { name: /close early/i }).click();
+  await page.getByRole("button", { name: /close account/i }).last().click();
+
+  // Toggle on
+  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+
+  await expect(page.getByText("Meridian 6M TD", { exact: true })).toBeVisible();
+  await expect(page.getByText("Closed").first()).toBeVisible();
+});
+
+// ─── Close Account (open-ended savings) ───────────────────────────────────────
+
+test("close account (savings) — dialog has no maturity warning", async ({ page }) => {
+  await seedAndGo(page, [savingsActive]);
+
+  await page.getByRole("button", { name: /more options for apex savings account/i }).click();
+  await page.getByRole("menuitem", { name: /close account/i }).click();
+
+  await expect(page.getByRole("alertdialog")).toBeVisible();
+  await expect(page.getByText(/closing before maturity/i)).not.toBeVisible();
+  await expect(page.getByText(/accrued net interest/i)).toBeVisible();
+});
+
+test("close account (savings) — confirm hides the savings deposit", async ({ page }) => {
+  await seedAndGo(page, [savingsActive]);
+
+  await page.getByRole("button", { name: /more options for apex savings account/i }).click();
+  await page.getByRole("menuitem", { name: /close account/i }).click();
+  await page.getByRole("button", { name: /close account/i }).last().click();
+
+  await expect(page.getByText("Apex Savings Account", { exact: true })).not.toBeVisible();
+});
+
+// ─── Pre-existing closed deposit ──────────────────────────────────────────────
+
+test("closed deposit hidden by default, shown after toggle", async ({ page }) => {
+  await seedAndGo(page, [tdClosed]);
+
+  await expect(page.getByText("Horizon 3M (closed)")).not.toBeVisible();
+
+  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+
+  await expect(page.getByText("Horizon 3M (closed)")).toBeVisible();
+  await expect(page.getByText("Closed").first()).toBeVisible();
+});
+
+// ─── Reopen ───────────────────────────────────────────────────────────────────
+
+test("reopen — closed deposit reverts to active after reopening", async ({ page }) => {
+  await seedAndGo(page, [tdClosed]);
+
+  // Show closed deposits first
+  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await expect(page.getByText("Horizon 3M (closed)")).toBeVisible();
+
+  await page.getByRole("button", { name: /more options for horizon 3m \(closed\)/i }).click();
+  await page.getByRole("menuitem", { name: /reopen/i }).click();
+
+  // After reopening, toggle back off — deposit should be visible (active)
+  await page.getByRole("switch", { name: "Show closed / settled" }).click();
+  await expect(page.getByText("Horizon 3M (closed)")).toBeVisible();
+  await expect(page.getByText("Active").first()).toBeVisible();
+});

--- a/tests/flows/investments.spec.ts
+++ b/tests/flows/investments.spec.ts
@@ -247,14 +247,14 @@ test("investments table — show settled toggle reveals all closed/settled depos
   await snap(page, "Investments - table view filled");
 });
 
-test("investments table — show closed/settled toggle does not hide matured deposits", async ({ page }) => {
+test("investments table — show inactive toggle does not hide matured deposits", async ({ page }) => {
   await seedAndGo(page);
 
   // Matured visible before toggle
   await expect(page.getByText("Meridian 3M (matured)")).toBeVisible();
   await expect(page.getByText("Apex 6M (matured)")).toBeVisible();
 
-  // Toggle closed/settled (off → on → off cycle to confirm matured is unaffected)
+  // Toggle inactive (off → on → off cycle to confirm matured is unaffected)
   await page.getByRole('switch', { name: 'Show inactive' }).click();
   await expect(page.getByText("Meridian 3M (matured)")).toBeVisible();
   await expect(page.getByText("Apex 6M (matured)")).toBeVisible();

--- a/tests/flows/investments.spec.ts
+++ b/tests/flows/investments.spec.ts
@@ -160,6 +160,26 @@ const seedDeposits: TimeDeposit[] = [
     isOpenEnded: false,
     status: "settled",
   },
+  // Closed
+  {
+    id: "close-td-closed",
+    bankId: "Horizon Digital Bank",
+    name: "Horizon 3M (closed)",
+    principal: 150000,
+    startDate: "2025-10-01",
+    termMonths: 12,
+    interestMode: "simple",
+    interestTreatment: "payout",
+    compounding: "daily",
+    taxRateOverride: 0.2,
+    flatRate: 0.055,
+    tiers: [{ upTo: null, rate: 0.055 }],
+    payoutFrequency: "maturity",
+    dayCountConvention: 365,
+    isOpenEnded: false,
+    status: "closed",
+    closeDate: "2026-01-15",
+  },
 ];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -185,7 +205,7 @@ test("investments table — renders column headers with data", async ({ page }) 
   }
 });
 
-test("investments table — shows active and matured deposits, hides settled by default", async ({ page }) => {
+test("investments table — shows active and matured deposits, hides closed/settled by default", async ({ page }) => {
   await seedAndGo(page);
 
   // Active deposits visible
@@ -213,13 +233,13 @@ test("investments table — matured deposits visible with Matured status", async
   await expect(page.getByText("Matured").first()).toBeVisible();
 });
 
-test("investments table — show settled toggle reveals all settled deposits", async ({ page }) => {
+test("investments table — show settled toggle reveals all closed/settled deposits", async ({ page }) => {
   await seedAndGo(page);
 
   await expect(page.getByText("Horizon 6M (settled)")).not.toBeVisible();
   await expect(page.getByText("Citadel 3M (settled)")).not.toBeVisible();
 
-  await page.getByRole('switch', { name: 'Show settled' }).click();
+  await page.getByRole('switch', { name: 'Show closed / settled' }).click();
 
   await expect(page.getByText("Horizon 6M (settled)")).toBeVisible();
   await expect(page.getByText("Citadel 3M (settled)")).toBeVisible();
@@ -227,15 +247,15 @@ test("investments table — show settled toggle reveals all settled deposits", a
   await snap(page, "Investments - table view filled");
 });
 
-test("investments table — show settled toggle does not hide matured deposits", async ({ page }) => {
+test("investments table — show closed/settled toggle does not hide matured deposits", async ({ page }) => {
   await seedAndGo(page);
 
   // Matured visible before toggle
   await expect(page.getByText("Meridian 3M (matured)")).toBeVisible();
   await expect(page.getByText("Apex 6M (matured)")).toBeVisible();
 
-  // Toggle settled (off → on → off cycle to confirm matured is unaffected)
-  await page.getByRole('switch', { name: 'Show settled' }).click();
+  // Toggle closed/settled (off → on → off cycle to confirm matured is unaffected)
+  await page.getByRole('switch', { name: 'Show closed / settled' }).click();
   await expect(page.getByText("Meridian 3M (matured)")).toBeVisible();
   await expect(page.getByText("Apex 6M (matured)")).toBeVisible();
 });
@@ -293,7 +313,7 @@ test("investments ladder — timeline region renders with deposits", async ({ pa
   await expect(ladderRegion.getByText("Horizon 6M (settled)")).not.toBeVisible;
   await expect(ladderRegion.getByText("Citadel 3M (settled)")).not.toBeVisible();
 
-  await page.getByRole('switch', { name: 'Show settled' }).click();
+  await page.getByRole('switch', { name: 'Show closed / settled' }).click();
 
   await expect(ladderRegion.getByText("Horizon 6M (settled)")).toBeVisible();
   await expect(ladderRegion.getByText("Citadel 3M (settled)")).toBeVisible();

--- a/tests/flows/investments.spec.ts
+++ b/tests/flows/investments.spec.ts
@@ -239,7 +239,7 @@ test("investments table — show settled toggle reveals all closed/settled depos
   await expect(page.getByText("Horizon 6M (settled)")).not.toBeVisible();
   await expect(page.getByText("Citadel 3M (settled)")).not.toBeVisible();
 
-  await page.getByRole('switch', { name: 'Show closed / settled' }).click();
+  await page.getByRole('switch', { name: 'Show inactive' }).click();
 
   await expect(page.getByText("Horizon 6M (settled)")).toBeVisible();
   await expect(page.getByText("Citadel 3M (settled)")).toBeVisible();
@@ -255,7 +255,7 @@ test("investments table — show closed/settled toggle does not hide matured dep
   await expect(page.getByText("Apex 6M (matured)")).toBeVisible();
 
   // Toggle closed/settled (off → on → off cycle to confirm matured is unaffected)
-  await page.getByRole('switch', { name: 'Show closed / settled' }).click();
+  await page.getByRole('switch', { name: 'Show inactive' }).click();
   await expect(page.getByText("Meridian 3M (matured)")).toBeVisible();
   await expect(page.getByText("Apex 6M (matured)")).toBeVisible();
 });
@@ -313,7 +313,7 @@ test("investments ladder — timeline region renders with deposits", async ({ pa
   await expect(ladderRegion.getByText("Horizon 6M (settled)")).not.toBeVisible;
   await expect(ladderRegion.getByText("Citadel 3M (settled)")).not.toBeVisible();
 
-  await page.getByRole('switch', { name: 'Show closed / settled' }).click();
+  await page.getByRole('switch', { name: 'Show inactive' }).click();
 
   await expect(ladderRegion.getByText("Horizon 6M (settled)")).toBeVisible();
   await expect(ladderRegion.getByText("Citadel 3M (settled)")).toBeVisible();


### PR DESCRIPTION
## Summary
This consolidated PR introduces the "Close Account" feature for early withdrawals, adds matured investment navigation badges for improved wayfinding, and executes a comprehensive architectural cleanup to resolve technical debt and state synchronization issues.

## Key Changes

### 🏦 Investment Lifecycle & Closure
- **New Terminal State**: Added `"closed"` status and `closeDate` field to represent early withdrawals or closed savings accounts.
- **Accrued Interest**: Implemented `calculateAccruedToDate` to pro-rate net interest based on days held, ensuring accurate payouts for non-matured exits.
- **Closure UX**: Added `CloseConfirmDialog` with specific warnings for Time Deposits and a simplified "Withdraw & close" flow for open-ended accounts.

### 🧭 Navigation & Wayfinding
- **Matured Badges**: Introduced a `primary` variant badge to the "Investments" nav item on both `SidebarNav` (desktop) and `BottomTabBar` (mobile).
- **Dynamic Signaling**: Badges automatically reflect the count of matured investments requiring action and disappear once all accounts are settled or rolled over.

### 🏗️ Architecture & Performance
- **Unified Actions**: Extracted `DepositActions.tsx` to standardize the management menu across Table and Card views, fixing label wrapping issues via a new `min-w-(--dropdown-content-min-w)` token.
- **Cash Flow Split**: Refactored engine into `buildCashFlowProjection` (forward-looking) and `buildCashFlowLedger` (historical) to correctly bucket early-closure proceeds.
- **State Reliability**: Updated `usePortfolioData` to refresh `today` every minute and refactored `PortfolioContext` mutations to prevent highlight timer race conditions.

### 🧪 Quality Assurance
- **Expanded Testing**: Added unit tests for tiered-rate closure logic, component tests for the closure dialog, and E2E Playwright flows for the "Undo" (Reopen) action.
- **A11y**: Integrated `aria-live` announcements for deletions and raised the Axe-core threshold to block `serious` violations.