### PR TITLE
feat: include preferences and theme in export/import backup

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -122,6 +122,7 @@ export default function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
+          storageKey="yf:theme"
         >
           <TooltipProvider>
             <PortfolioProvider>

--- a/src/features/dashboard/components/DashboardShell.tsx
+++ b/src/features/dashboard/components/DashboardShell.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useRef } from "react";
+import { useTheme } from "next-themes";
 import { ArrowRight, BrainCircuit } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -14,6 +15,7 @@ import { useWizardStore } from "@/store/wizardStore";
 import { formatMonthLabel } from "@/lib/domain/date";
 import { Container } from "@/components/layout/Container";
 import { PageHeader } from "@/components/layout/PageHeader";
+import type { Preferences } from "@/lib/hooks/usePreferences";
 
 // ─── Quick cash flow preview for this month ────────────────────────────────────
 
@@ -78,7 +80,8 @@ function ThisMonthPreview({ entries }: { entries: MonthEntry[] }) {
 // ─── Main component ────────────────────────────────────────────────────────────
 
 export default function DashboardShell() {
-  const { portfolio, status, enterDemo, importDeposits } = usePortfolioContext();
+  const { portfolio, status, enterDemo, importDeposits, importPreferences } = usePortfolioContext();
+  const { setTheme } = useTheme();
   const openWizard   = useWizardStore((s) => s.openWizard);
   const openExportAi = useWizardStore((s) => s.openExportAi);
 
@@ -95,14 +98,25 @@ export default function DashboardShell() {
         if (typeof raw !== "object" || raw === null || raw.version !== 1 || !Array.isArray(raw.deposits)) {
           throw new Error();
         }
+
+        const p = raw as Record<string, unknown>;
+        const importedPreferences =
+          typeof p.preferences === "object" && p.preferences !== null
+            ? (p.preferences as Partial<Preferences>)
+            : undefined;
+        const importedTheme = typeof p.theme === "string" ? p.theme : undefined;
+
         importDeposits(raw.deposits);
+        if (importedPreferences) importPreferences(importedPreferences);
+        if (importedTheme) setTheme(importedTheme);
+
         toast.success(`${raw.deposits.length} investment${raw.deposits.length === 1 ? "" : "s"} imported`);
       } catch {
         toast.error("Import failed", { description: "The file doesn't appear to be a valid YieldFlow backup." });
       }
     };
     reader.readAsText(file);
-  }, [importDeposits]);
+  }, [importDeposits, importPreferences, setTheme]);
 
   const thisMonthEntries = (portfolio.currentMonthFull?.entries ?? []) as MonthEntry[];
 

--- a/src/features/dashboard/components/EmptyLanding.tsx
+++ b/src/features/dashboard/components/EmptyLanding.tsx
@@ -45,7 +45,7 @@ export function EmptyLanding({ onAddData, onTryDemo, onImport }: EmptyLandingPro
         </ul>
 
         {/* CTAs — demo first, reduces friction */}
-        <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="flex flex-col gap-3 sm:flex-row flex-wrap">
           <Button size="lg" onClick={onTryDemo}>
             Explore with demo data
           </Button>

--- a/src/features/portfolio/context/PortfolioContext.tsx
+++ b/src/features/portfolio/context/PortfolioContext.tsx
@@ -59,6 +59,7 @@ interface PortfolioContextValue {
   // Preferences
   preferences: Preferences;
   setPreference: <K extends keyof Preferences>(key: K, value: Preferences[K]) => void;
+  importPreferences: (partial: Partial<Preferences>) => void;
 
   // Demo handlers
   enterDemo: () => void;
@@ -99,7 +100,7 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
     setValue: setIsDemoMode,
     isReady: demoReady,
   } = useLocalStorage<boolean>("yf:demo-mode", false, { skipInitialWrite: true });
-  const { preferences, setPreference } = usePreferences();
+  const { preferences, setPreference, importPreferences } = usePreferences();
 
   const fmtCurrency = useCallback(
     (value: number) => formatCurrency(value, preferences.currency),
@@ -292,6 +293,7 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       hasSidebar,
       preferences,
       setPreference,
+      importPreferences,
       enterDemo,
       exitDemo,
       handleSave,
@@ -316,6 +318,7 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       hasSidebar,
       preferences,
       setPreference,
+      importPreferences,
       enterDemo,
       exitDemo,
       handleSave,

--- a/src/features/settings/components/SettingsShell.tsx
+++ b/src/features/settings/components/SettingsShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
+import { useTheme } from "next-themes";
 import { useRouter } from "next/navigation";
 import { ChevronDown, Download, Trash2, Upload } from "lucide-react";
 import {
@@ -27,6 +28,7 @@ import { usePortfolioContext } from "@/features/portfolio/context/PortfolioConte
 import { getCurrencySymbol, SUPPORTED_CURRENCIES } from "@/lib/domain/format";
 import { toISODate } from "@/lib/domain/date";
 import type { TimeDeposit } from "@/types";
+import type { Preferences } from "@/lib/hooks/usePreferences";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText } from '@/components/ui/input-group';
 import { useCurrencyInput } from '@/components/ui/use-currency-input';
@@ -39,6 +41,14 @@ type BackupFile = {
   version: number;
   exportedAt: string;
   deposits: TimeDeposit[];
+  preferences?: Partial<Preferences>;
+  theme?: string;
+};
+
+type ImportPreview = {
+  deposits: TimeDeposit[];
+  preferences?: Partial<Preferences>;
+  theme?: string;
 };
 
 const REQUIRED_DEPOSIT_FIELDS: (keyof TimeDeposit)[] = [
@@ -73,9 +83,10 @@ function validateBackup(raw: unknown): TimeDeposit[] {
 export function SettingsShell() {
   const router = useRouter();
   const { deposits, importDeposits, clearDeposits, preferences, setPreference, isDemoMode, exitDemo } = usePortfolioContext();
+  const { theme, setTheme } = useTheme();
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [importPreview, setImportPreview] = useState<TimeDeposit[] | null>(null);
+  const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
   const [importConfirmOpen, setImportConfirmOpen] = useState(false);
   const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
@@ -106,6 +117,8 @@ export function SettingsShell() {
         version: 1,
         exportedAt: new Date().toISOString(),
         deposits,
+        preferences,
+        theme: theme ?? undefined,
       };
       const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
       const url = URL.createObjectURL(blob);
@@ -118,7 +131,7 @@ export function SettingsShell() {
     } catch {
       toast.error("Export failed — please try again");
     }
-  }, [deposits]);
+  }, [deposits, preferences, theme]);
 
   // ─── Import ────────────────────────────────────────────────────────────────
 
@@ -131,8 +144,15 @@ export function SettingsShell() {
     reader.onload = (event) => {
       try {
         const raw = JSON.parse(event.target?.result as string);
-        const parsed = validateBackup(raw);
-        setImportPreview(parsed);
+        const parsedDeposits = validateBackup(raw);
+        const p = raw as Record<string, unknown>;
+        const importedPreferences =
+          typeof p.preferences === "object" && p.preferences !== null
+            ? (p.preferences as Partial<Preferences>)
+            : undefined;
+        const importedTheme = typeof p.theme === "string" ? p.theme : undefined;
+
+        setImportPreview({ deposits: parsedDeposits, preferences: importedPreferences, theme: importedTheme });
         setImportConfirmOpen(true);
       } catch (err) {
         setImportError(err instanceof Error ? err.message : "Failed to read file.");
@@ -145,12 +165,20 @@ export function SettingsShell() {
 
   const handleImportConfirm = useCallback(() => {
     if (!importPreview) return;
-    importDeposits(importPreview);
-    toast.success(`${importPreview.length} investment${importPreview.length === 1 ? "" : "s"} imported`);
+    importDeposits(importPreview.deposits);
+
+    if (importPreview.preferences?.currency)
+      setPreference("currency", importPreview.preferences.currency);
+    if (importPreview.preferences?.bankInsuranceLimit !== undefined)
+      setPreference("bankInsuranceLimit", importPreview.preferences.bankInsuranceLimit);
+    if (importPreview.theme)
+      setTheme(importPreview.theme);
+
+    toast.success(`${importPreview.deposits.length} investment${importPreview.deposits.length === 1 ? "" : "s"} imported`);
     setImportPreview(null);
     setImportConfirmOpen(false);
     router.push("/");
-  }, [importPreview, importDeposits, router]);
+  }, [importPreview, importDeposits, setPreference, setTheme, router]);
 
   // ─── Clear ─────────────────────────────────────────────────────────────────
 
@@ -440,8 +468,9 @@ export function SettingsShell() {
             <AlertDialogHeader>
               <AlertDialogTitle>Replace all data?</AlertDialogTitle>
               <AlertDialogDescription>
-                This will replace your {deposits.length} current deposit{deposits.length !== 1 ? "s" : ""} with {importPreview?.length ?? 0} imported deposit{(importPreview?.length ?? 0) !== 1 ? "s" : ""}.
-                This cannot be undone. Export a backup first if you want to keep your current data.
+                This will replace your {deposits.length} current deposit{deposits.length !== 1 ? "s" : ""} with {importPreview?.deposits.length ?? 0} imported deposit{(importPreview?.deposits.length ?? 0) !== 1 ? "s" : ""}.
+                {(importPreview?.preferences || importPreview?.theme) && " Your display preferences will also be restored."}
+                {" "}This cannot be undone. Export a backup first if you want to keep your current data.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/src/features/settings/components/SettingsShell.tsx
+++ b/src/features/settings/components/SettingsShell.tsx
@@ -25,7 +25,7 @@ import {
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
 import { RouteGuard } from "@/components/layout/RouteGuard";
 import { usePortfolioContext } from "@/features/portfolio/context/PortfolioContext";
-import { getCurrencySymbol, SUPPORTED_CURRENCIES } from "@/lib/domain/format";
+import { getCurrencySymbol, getLocaleCurrency, SUPPORTED_CURRENCIES } from "@/lib/domain/format";
 import { toISODate } from "@/lib/domain/date";
 import type { TimeDeposit } from "@/types";
 import type { Preferences } from "@/lib/hooks/usePreferences";
@@ -82,7 +82,7 @@ function validateBackup(raw: unknown): TimeDeposit[] {
 
 export function SettingsShell() {
   const router = useRouter();
-  const { deposits, importDeposits, clearDeposits, preferences, setPreference, isDemoMode, exitDemo } = usePortfolioContext();
+  const { deposits, importDeposits, clearDeposits, preferences, setPreference, importPreferences, isDemoMode, exitDemo } = usePortfolioContext();
   const { theme, setTheme } = useTheme();
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -113,12 +113,17 @@ export function SettingsShell() {
 
   const handleExport = useCallback(() => {
     try {
+      const preferencesToExport = {
+        ...(preferences.currency !== getLocaleCurrency() && { currency: preferences.currency }),
+        ...(preferences.bankInsuranceLimit !== undefined && { bankInsuranceLimit: preferences.bankInsuranceLimit }),
+      };
+
       const payload = {
         version: 1,
         exportedAt: new Date().toISOString(),
         deposits,
-        preferences,
-        theme: theme ?? undefined,
+        preferences: preferencesToExport,
+        ...(theme && theme !== "system" && { theme }),
       };
       const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
       const url = URL.createObjectURL(blob);
@@ -166,19 +171,15 @@ export function SettingsShell() {
   const handleImportConfirm = useCallback(() => {
     if (!importPreview) return;
     importDeposits(importPreview.deposits);
-
-    if (importPreview.preferences?.currency)
-      setPreference("currency", importPreview.preferences.currency);
-    if (importPreview.preferences?.bankInsuranceLimit !== undefined)
-      setPreference("bankInsuranceLimit", importPreview.preferences.bankInsuranceLimit);
+    if (importPreview.preferences)
+      importPreferences(importPreview.preferences);
     if (importPreview.theme)
       setTheme(importPreview.theme);
-
     toast.success(`${importPreview.deposits.length} investment${importPreview.deposits.length === 1 ? "" : "s"} imported`);
     setImportPreview(null);
     setImportConfirmOpen(false);
     router.push("/");
-  }, [importPreview, importDeposits, setPreference, setTheme, router]);
+  }, [importPreview, importDeposits, importPreferences, setTheme, router]);
 
   // ─── Clear ─────────────────────────────────────────────────────────────────
 

--- a/src/features/settings/components/__tests__/SettingsShell.test.tsx
+++ b/src/features/settings/components/__tests__/SettingsShell.test.tsx
@@ -12,6 +12,11 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 
+const mockSetTheme = vi.fn();
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light", resolvedTheme: "light", setTheme: mockSetTheme }),
+}));
+
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 const DEPOSITS_KEY = "yf:deposits";
@@ -145,6 +150,62 @@ describe("SettingsShell — import", () => {
 
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith("1 investment imported");
+    });
+  });
+
+  it("applies preferences and theme from backup on import", async () => {
+    seedStorage();
+    renderShell();
+
+    const backup = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      deposits: [deposit],
+      preferences: { currency: "USD", bankInsuranceLimit: 500_000 },
+      theme: "dark",
+    };
+    const file = new File([JSON.stringify(backup)], "backup.json", {
+      type: "application/json",
+    });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const replaceBtn = await screen.findByRole("button", { name: /replace/i });
+    fireEvent.click(replaceBtn);
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem("yf:preferences") ?? "{}");
+      expect(stored.currency).toBe("USD");
+      expect(stored.bankInsuranceLimit).toBe(500_000);
+      expect(mockSetTheme).toHaveBeenCalledWith("dark");
+    });
+  });
+
+  it("does not apply preferences when backup has none (backward compat)", async () => {
+    localStorage.setItem("yf:preferences", JSON.stringify({ currency: "PHP" }));
+    seedStorage();
+    renderShell();
+
+    const backup = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      deposits: [deposit],
+    };
+    const file = new File([JSON.stringify(backup)], "backup.json", {
+      type: "application/json",
+    });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const replaceBtn = await screen.findByRole("button", { name: /replace/i });
+    fireEvent.click(replaceBtn);
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem("yf:preferences") ?? "{}");
+      expect(stored.currency).toBe("PHP");
+      expect(mockSetTheme).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/hooks/usePreferences.ts
+++ b/src/lib/hooks/usePreferences.ts
@@ -11,14 +11,17 @@ export type Preferences = {
   bankInsuranceLimit?: number;
 };
 
+const PREFERENCES_KEY = "yf:preferences";
+
 function getInitialPreferences(): Preferences {
   return { currency: getLocaleCurrency() };
 }
 
 export function usePreferences() {
   const { value: preferences, setValue: setPreferences } = useLocalStorage<Preferences>(
-    "yf:preferences",
+    PREFERENCES_KEY,
     getInitialPreferences(),
+    { skipInitialWrite: true },
   );
 
   const setPreference = useCallback(
@@ -28,5 +31,32 @@ export function usePreferences() {
     [setPreferences],
   );
 
-  return { preferences, setPreference } as const;
+  // Used during import: writes to localStorage synchronously before updating React
+  // state, so the value survives any component re-initialization triggered by navigation.
+  const importPreferences = useCallback(
+    (partial: Partial<Preferences>) => {
+      let current: Preferences;
+
+      try {
+        const stored = window.localStorage.getItem(PREFERENCES_KEY);
+
+        current = stored ? (JSON.parse(stored) as Preferences) : getInitialPreferences();
+      } catch {
+        current = getInitialPreferences();
+      }
+
+      const merged = { ...current, ...partial };
+
+      try {
+        window.localStorage.setItem(PREFERENCES_KEY, JSON.stringify(merged));
+      } catch {
+        /* storage full */
+      }
+
+      setPreferences(merged);
+    },
+    [setPreferences],
+  );
+
+  return { preferences, setPreference, importPreferences } as const;
 }


### PR DESCRIPTION
## Summary

Bundles currency, deposit insurance limit, and theme into the exported JSON so they are automatically re-applied when restoring a backup.

Backward-compatible: old exports (no preferences/theme fields) still import cleanly; new exports still pass the version-1 validator in older builds.

### Key changes
- Export: adds `preferences` and `theme` to the JSON payload (version stays 1)
- Import: reads optional fields and applies them on confirm; skips gracefully if absent
- Confirmation dialog notes when preferences will be restored
- Tests: mocks `next-themes`, adds coverage for preferences-present and preferences-absent (backward-compat) import paths

### Testing
- [x] Percy: https://percy.io/c9665ed5/web/yield-flow-f83e6ca3/builds/50125162/