### PR TITLE
chore: bump minor/patch dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4610,9 +4610,10 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -5002,10 +5003,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -8241,6 +8243,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11188,9 +11191,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "yield-flow",
       "version": "0.1.0",
       "dependencies": {
-        "@base-ui/react": "^1.4.1",
+        "@base-ui/react": "^1.5.0",
         "@tanstack/react-table": "^8.21.3",
         "@testing-library/dom": "^10.4.1",
         "@vercel/analytics": "^2.0.1",
@@ -22,7 +22,7 @@
         "react-day-picker": "^10.0.1",
         "react-dom": "19.2.6",
         "recharts": "^3.8.1",
-        "shadcn": "^4.7.0",
+        "shadcn": "^4.8.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
@@ -32,23 +32,23 @@
         "@axe-core/playwright": "^4.11.3",
         "@emnapi/core": "^1.10.0",
         "@emnapi/runtime": "^1.10.0",
-        "@percy/cli": "^1.31.13",
+        "@percy/cli": "^1.31.14",
         "@percy/playwright": "^1.1.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^25.9.0",
-        "@types/react": "^19",
+        "@types/node": "^25.9.1",
+        "@types/react": "^19.2.15",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.2",
         "eslint": "^9.39.4",
-        "eslint-config-next": "16.2.6",
+        "eslint-config-next": "^16.2.6",
         "jsdom": "^29.1.1",
         "playwright": "^1.60.0",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -517,13 +517,13 @@
       }
     },
     "node_modules/@base-ui/react": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
-      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.5.0.tgz",
+      "integrity": "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.2.8",
+        "@base-ui/utils": "0.2.9",
         "@floating-ui/react-dom": "^2.1.8",
         "@floating-ui/utils": "^0.2.11",
         "use-sync-external-store": "^1.6.0"
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/@base-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -2108,22 +2108,22 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.13.tgz",
-      "integrity": "sha512-QpNpqt4rpmQMOixvWzds2bMKaNT64cUNsELokM0jAP8wSbKZLAsvWddM24fZTqsKXpm4peBpzO73S3bwV0Ep5w==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.14.tgz",
+      "integrity": "sha512-/gaJJz+Em4nVFAq57tDPg2IY+ju5ORrANZP/xHBp6koNhEnzwpgkgDRU23jUsPiNQ2UO3uKnlpzbRhvfUuhAPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-app": "1.31.13",
-        "@percy/cli-build": "1.31.13",
-        "@percy/cli-command": "1.31.13",
-        "@percy/cli-config": "1.31.13",
-        "@percy/cli-doctor": "1.31.13",
-        "@percy/cli-exec": "1.31.13",
-        "@percy/cli-snapshot": "1.31.13",
-        "@percy/cli-upload": "1.31.13",
-        "@percy/client": "1.31.13",
-        "@percy/logger": "1.31.13"
+        "@percy/cli-app": "1.31.14",
+        "@percy/cli-build": "1.31.14",
+        "@percy/cli-command": "1.31.14",
+        "@percy/cli-config": "1.31.14",
+        "@percy/cli-doctor": "1.31.14",
+        "@percy/cli-exec": "1.31.14",
+        "@percy/cli-snapshot": "1.31.14",
+        "@percy/cli-upload": "1.31.14",
+        "@percy/client": "1.31.14",
+        "@percy/logger": "1.31.14"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -2133,42 +2133,42 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.13.tgz",
-      "integrity": "sha512-onVbiQkG2FaAnP9rw1OtCR/8OkD0lo/S8Cz56Qe3sln/kJtfEC1VAsTq9x/e3caeNFPh7aObF78o8BVvIexcNQ==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.14.tgz",
+      "integrity": "sha512-V9L8EiLYzPsD1W4Rot3cBEYCrr81ZSseJEiHKtYCCWcjZYk5kTZdFJc8YjYE3KLFMUkxVIcRmCQeHE5Awcu8RA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.13",
-        "@percy/cli-exec": "1.31.13"
+        "@percy/cli-command": "1.31.14",
+        "@percy/cli-exec": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.13.tgz",
-      "integrity": "sha512-tsAr+pzGe5LqRNJiB4CBo7YDBXqH/uXm/89iovwor8wkqDgHR3DfC8u5+GgNNbfazEG2nDx4l3QmmOvN+APARw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.14.tgz",
+      "integrity": "sha512-jxp+XRxKJ3xr3ZKmjpaHI1oY5OMuPYvWP/EBzzPxUi8vbmJe5pMxjj9EplcnTJYCABsfQviwazedbrCDitYdPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.13"
+        "@percy/cli-command": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.13.tgz",
-      "integrity": "sha512-pGcs0yPocP3bXqpkzS1UThoQ+8ayVDXLBtpSU+/7N0Rnj6R0eUD1xWggobPT7pY1EOrWqKMEzb67scEvrSIq7Q==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.14.tgz",
+      "integrity": "sha512-rLDR8dqHuUMQf4QfoStcQ1YTjdahGHOLn8IgA4ZC/o0H/9o2ynDIckMfQRgPYwBSwJDZU/pFZmuFGXiC8l/3tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.13",
-        "@percy/core": "1.31.13",
-        "@percy/logger": "1.31.13"
+        "@percy/config": "1.31.14",
+        "@percy/core": "1.31.14",
+        "@percy/logger": "1.31.14"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -2178,32 +2178,32 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.13.tgz",
-      "integrity": "sha512-t0K7SYCeWp+UrRMqrTmzZiidBTxWkAvNqCyrExa5yQy3GJXyYqhygqymfP8Y5+8e2SbIGBoXZQW0fIzoSc83ww==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.14.tgz",
+      "integrity": "sha512-wz/mmJMRSEfSVtD26aeorx5ZpzDw2SuETM6CxbNS1+SPvQT+NyKTWoqjOmboBn3AmVq4IYoRgbAfz/irOSkhZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.13"
+        "@percy/cli-command": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-doctor": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-doctor/-/cli-doctor-1.31.13.tgz",
-      "integrity": "sha512-sX+VNyyTZ3viFW75NPFYMTjD+CHraD43VJ7K5Mpt4hq2IR8LS1J0C37kAiMJnTwFHeeXpaaIsCxVrKiS+jHvOQ==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-doctor/-/cli-doctor-1.31.14.tgz",
+      "integrity": "sha512-UjH6LUvAWoX3HUFg9qcxo7bRVb6Y41/RCFYbAdC+/jZF/IX+FU3wnmGD8s0FZs4L+wlz6PXSJtIzAcyQGRas1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.13",
-        "@percy/client": "1.31.13",
-        "@percy/config": "1.31.13",
-        "@percy/core": "1.31.13",
-        "@percy/env": "1.31.13",
-        "@percy/logger": "1.31.13",
-        "@percy/monitoring": "1.31.13",
+        "@percy/cli-command": "1.31.14",
+        "@percy/client": "1.31.14",
+        "@percy/config": "1.31.14",
+        "@percy/core": "1.31.14",
+        "@percy/env": "1.31.14",
+        "@percy/logger": "1.31.14",
+        "@percy/monitoring": "1.31.14",
         "minimatch": "^9.0.0",
         "ws": "^8.17.1"
       },
@@ -2212,14 +2212,14 @@
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.13.tgz",
-      "integrity": "sha512-93w98Mejp2V7vuXgvEdwbJ4odHa3KHHJ6yrWkvydhKe0FmjoEnH20fYpZ1661Rh6YPTm61a/VvspoWEMD7E+5g==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.14.tgz",
+      "integrity": "sha512-Vs7Tulw2tM4Z/tDLpU/Stc+29hHl3g8Z5gfIPBPBfcTcIp4Ws6F7tKDO0NBzXsIGv9JuLhnc2zQvEIPCrDcV0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.13",
-        "@percy/logger": "1.31.13",
+        "@percy/cli-command": "1.31.14",
+        "@percy/logger": "1.31.14",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -2228,13 +2228,13 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.13.tgz",
-      "integrity": "sha512-k9gG8ImwbcLZPeLtanBETdT8qWvAIKPcZXJ0P8OnoL+onyqEbT/BuYNTY7tlezWDg5utJFwT4LczOqAnHdS0AA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.14.tgz",
+      "integrity": "sha512-JdE8mJ0PSwSO5T4V0B1qrM5SP1MPCssQTkcPgnUY2ykNKS7ePr6vzd4USn/Ex4rqIJydT6MeoUPptV051owsRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.13",
+        "@percy/cli-command": "1.31.14",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -2242,13 +2242,13 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.13.tgz",
-      "integrity": "sha512-+/HkIGWqHH/EJmbxATXO0N8XnwtXrhnePDKFZtWx7JrpaZXxRXI96NGL7/mjKQ2sAQKPSGvbbUAB++UoFZSnYg==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.14.tgz",
+      "integrity": "sha512-VEhjW4hnRJAnYWoqLnFsJJ0m3JXohPBOPoqUtL3/P3fgXvWfVYtavSwlgjrWmS7YZ0z6gIT02Isd6i8wwnIGAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.13",
+        "@percy/cli-command": "1.31.14",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -2257,15 +2257,15 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.13.tgz",
-      "integrity": "sha512-eFoUacW2GolCm3rL8oS1QyWD6b4UWds9HrMbtp6OJWUr6sQ8bcOemjr3M1YpkDsV2wGC0ikLISQxU8XrTxKDhA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.14.tgz",
+      "integrity": "sha512-HA/1SlYg57L3eNQZivNJ5yKZte8v7ZZ3CT29hhn03sHReVd3NshQuSC1Vm8kchrnoSi4SR5bUilwJ9w8lnDT3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.13",
-        "@percy/env": "1.31.13",
-        "@percy/logger": "1.31.13",
+        "@percy/config": "1.31.14",
+        "@percy/env": "1.31.14",
+        "@percy/logger": "1.31.14",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       },
@@ -2274,13 +2274,13 @@
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.13.tgz",
-      "integrity": "sha512-gxd292C8+v/psxYJNfId2gwhlIGjvRGGOTCw9gBTb/eBT8cZirVLHq+d/j2nqPxCDC7JzZqChWH4TkVkTr/Xwg==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.14.tgz",
+      "integrity": "sha512-BRVfkff1j3ATdA8xH600802nhFfE1K4XRsGwOHTEZd/DnFVvGUIagQvfZxpTdHBTZ8G+nwi9Z8CTcVtzgd4AMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.31.13",
+        "@percy/logger": "1.31.14",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -2290,19 +2290,19 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.13.tgz",
-      "integrity": "sha512-SFVw/skIpcFecn8V3emAhmqqOgsX3K9toamMhhVay9FtAoy/NmsV+WuvP3IsAvujepY8ApZe2Zi5CuzZbmDy0w==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.14.tgz",
+      "integrity": "sha512-c6QTjqaKs7UxL9HK6VJJl5B57hywFNn+l22vES4dFkegrkdE0maAz7rG88X2Xp2sYrsR3qf9n9CKCDy511/KYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/client": "1.31.13",
-        "@percy/config": "1.31.13",
-        "@percy/dom": "1.31.13",
-        "@percy/logger": "1.31.13",
-        "@percy/monitoring": "1.31.13",
-        "@percy/webdriver-utils": "1.31.13",
+        "@percy/client": "1.31.14",
+        "@percy/config": "1.31.14",
+        "@percy/dom": "1.31.14",
+        "@percy/logger": "1.31.14",
+        "@percy/monitoring": "1.31.14",
+        "@percy/webdriver-utils": "1.31.14",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -2319,33 +2319,33 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@percy/cli-doctor": "1.31.13"
+        "@percy/cli-doctor": "1.31.14"
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.13.tgz",
-      "integrity": "sha512-5v/ybb2f4aQLUdsbQzTuHzQNAP5zcqn/aO18k2AjvnNdxNmtLC3XwMaSMznImQAXCGsSqsmrJTGtrYP3pbTPYw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.14.tgz",
+      "integrity": "sha512-Ilz9qSf9Z80jHah9b7OfX2M2N9vmY4hkGEhMO953ui3NSQhXZsezr4aIPREYdyZdo11pEWm+JWU1AEZw54CbbA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@percy/env": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.13.tgz",
-      "integrity": "sha512-oYEPbZwEtRFfuso+V1lnAZkZZC1gSk+H+//AdLU5De1+h2jxYW14qc1bpW707ZSina5DY5C2tcbsHNV4lcYI/A==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.14.tgz",
+      "integrity": "sha512-eRW4Ot2Z5WESKPJHcdLc9JFLtjxJaALzRxGa7Z+0R5t5wOlqbEVQytLBzgFWWTVa2XEejR4Sffs5cYqM+ldgEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.31.13"
+        "@percy/logger": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.13.tgz",
-      "integrity": "sha512-ym8Viw3mAGv00afk4NwaODBXLcS7/pPtpa/RSPS0knToPbCvN4/aE9PoZ99M8UbKY02ZFqGAbBNL+uPgS1nKbA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.14.tgz",
+      "integrity": "sha512-e078iCrSDa4qdMfOlX+DXhZ08MzYxNTFfz7HsgLcAXSn6AV+CGZT/BxaHlzm2I5tp1zQV7wHnvvm4RV2qx1FEA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2353,15 +2353,15 @@
       }
     },
     "node_modules/@percy/monitoring": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.13.tgz",
-      "integrity": "sha512-TNHrEA8juyvSM2Egnub9gEDi3p1yYXwGfa4F+H3Ub+zNWFZ/11vxFRQuryzN9aQha/hvcBnXFQJk8JR73I+T4g==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.14.tgz",
+      "integrity": "sha512-5zqOZmkua08pc/lppXeBUCEWCG9xGQwrxI+DlZ6TMLg05Dwn7nPRaMMxYla8A/XsDemcq0TECgCT83uYY0WpeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.13",
-        "@percy/logger": "1.31.13",
-        "@percy/sdk-utils": "1.31.13",
+        "@percy/config": "1.31.14",
+        "@percy/logger": "1.31.14",
+        "@percy/sdk-utils": "1.31.14",
         "systeminformation": "^5.25.11"
       },
       "engines": {
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.13.tgz",
-      "integrity": "sha512-0JW+ngBKLjkhbsI6ZD8wnWDV1U/S66X4vBrJqHLSi8t8BygQrulAwKLrtSV27DHCxz3a+zptTMBQufwFbal5gg==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.14.tgz",
+      "integrity": "sha512-I31GM+aCHiME12jX9ac5COThZWOpTBONkR9J6D059wqiFhHtRenA2mWFx6rC+zUpG5un0imkal7tN9y1D4hPBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2394,14 +2394,14 @@
       }
     },
     "node_modules/@percy/webdriver-utils": {
-      "version": "1.31.13",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.13.tgz",
-      "integrity": "sha512-wiCPRI42Vg6+qL/wiDMPkpauBHbpPJoiaMZB0gDyzrjHJx8cPwG85+oUOgvtMDNdvy55jAtcSdqzA5kXcvMsOw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.14.tgz",
+      "integrity": "sha512-2V4yxf60mXsDAUz+GFOePcfSNF9mSbrV1WH+sUWDItFUjV14QSVNuBcZRKO8Etgi7bFSCPz1Z1jXrxmopBFpbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.13",
-        "@percy/sdk-utils": "1.31.13"
+        "@percy/config": "1.31.14",
+        "@percy/sdk-utils": "1.31.14"
       },
       "engines": {
         "node": ">=14"
@@ -4751,19 +4751,20 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5432,16 +5433,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -5450,13 +5451,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5477,9 +5478,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5490,13 +5491,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5504,14 +5505,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5520,9 +5521,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5530,13 +5531,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5977,9 +5978,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8240,7 +8241,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8479,9 +8479,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12057,9 +12057,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/shadcn": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.7.0.tgz",
-      "integrity": "sha512-70fwnesNrY1GgeD7Kdzn+3SsYeyfibm8immsA5L68+OusoPTvYF01oWExl8/latKpMpvVXcbgdbbE6VFBJQ38w==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.8.0.tgz",
+      "integrity": "sha512-LAm3I/1FdoU/zu5GVG8Hbna4X9zlzEG5TeeCPXqsopkjvGk8QUF9OFhqeRN8oM6Oh/ynUI/yQHZxQAO3Ymcqsg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -13409,19 +13409,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -13449,12 +13449,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -13696,9 +13696,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:percy:dry": "npm run build && PLAYWRIGHT_WEB_SERVER=1 PLAYWRIGHT_WEB_SERVER_CMD=\"npm run start -- --hostname 127.0.0.1 --port 4173\" percy exec --dry-run -- playwright test --project=e2e"
   },
   "dependencies": {
-    "@base-ui/react": "^1.4.1",
+    "@base-ui/react": "^1.5.0",
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/dom": "^10.4.1",
     "@vercel/analytics": "^2.0.1",
@@ -32,7 +32,7 @@
     "react-day-picker": "^10.0.1",
     "react-dom": "19.2.6",
     "recharts": "^3.8.1",
-    "shadcn": "^4.7.0",
+    "shadcn": "^4.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
@@ -42,22 +42,22 @@
     "@axe-core/playwright": "^4.11.3",
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",
-    "@percy/cli": "^1.31.13",
+    "@percy/cli": "^1.31.14",
     "@percy/playwright": "^1.1.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^25.9.0",
-    "@types/react": "^19",
+    "@types/node": "^25.9.1",
+    "@types/react": "^19.2.15",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^9.39.4",
-    "eslint-config-next": "16.2.6",
+    "eslint-config-next": "^16.2.6",
     "jsdom": "^29.1.1",
     "playwright": "^1.60.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.7"
   }
 }


### PR DESCRIPTION
## Summary

Updates `@base-ui/react`, `shadcn`, `vitest`, `@types/node`, `@types/react`, and `@percy/cli` to their latest versions. ESLint 10 skipped; `eslint-plugin-react` (pinned inside `eslint-config-next`) does not yet support ESLint 10.


### Testing
- [x] Percy: https://percy.io/c9665ed5/web/yield-flow-f83e6ca3/builds/50126142