### PR TITLE
fix: trim rollover proceeds to 2 decimal places

### DIFF
--- a/src/lib/domain/__tests__/rollover.test.ts
+++ b/src/lib/domain/__tests__/rollover.test.ts
@@ -41,4 +41,11 @@ describe("getRolloverPrincipal", () => {
     const deposit: TimeDeposit = { ...BASE, payoutFrequency: "maturity" };
     expect(getRolloverPrincipal(deposit, 100_000)).toBe(100_000);
   });
+
+  it("TD maturity: rounds fractional proceeds to 2 decimals", () => {
+    const deposit: TimeDeposit = { ...BASE, payoutFrequency: "maturity" };
+    expect(getRolloverPrincipal(deposit, 103_249.999)).toBe(103_250);
+    expect(getRolloverPrincipal(deposit, 103_249.994)).toBe(103_249.99);
+    expect(getRolloverPrincipal(deposit, 103_249.995)).toBe(103_250);
+  });
 });

--- a/src/lib/domain/rollover.ts
+++ b/src/lib/domain/rollover.ts
@@ -9,6 +9,10 @@ import type { TimeDeposit } from "@/types";
  * - TD monthly (payoutFrequency === "monthly"): interest was already distributed
  *   each month. At maturity the user only receives the original principal back.
  */
+const trimToCents = (value: number) => Math.round(value * 100) / 100;
+
 export function getRolloverPrincipal(deposit: TimeDeposit, netTotal: number): number {
-  return deposit.payoutFrequency === "monthly" ? deposit.principal : netTotal;
+  return deposit.payoutFrequency === "monthly"
+    ? trimToCents(deposit.principal)
+    : trimToCents(netTotal);
 }


### PR DESCRIPTION
## Overview

When rolling over a matured TD, the wizard's principal field was pre-filled with the raw float from the yield engine (e.g. 103249.98999999998). This trims the proceeds to 2 decimals in `getRolloverPrincipal` before pre-filling.

- `src/lib/domain/rollover.ts`: round rollover principal with `Math.round(v * 100) / 100`; trailing `.00` still renders cleanly for whole amounts
- Add unit test for fractional proceeds rounding

### Testing
- [x] Percy: https://percy.io/c9665ed5/web/yield-flow-f83e6ca3/builds/52498093